### PR TITLE
Recipe #103 -- Annotating a Poetry Reading

### DIFF
--- a/recipe/0103-poetry-reading-annotations/annotations.json
+++ b/recipe/0103-poetry-reading-annotations/annotations.json
@@ -3,7 +3,7 @@ layout: null
 ---
 {
   "@context": "http://iiif.io/api/presentation/3/context.json",
-  "id": "{{site.url}}{{site.baseurl}}/{{page.path}}/annopage/p1",
+  "id": "{{site.url}}{{site.baseurl}}{{page.dir}}annotations.json",
   "type": "AnnotationPage",
   "items": 
   [

--- a/recipe/0103-poetry-reading-annotations/annotations.json
+++ b/recipe/0103-poetry-reading-annotations/annotations.json
@@ -2,7 +2,8 @@
   "@context": "http://iiif.io/api/presentation/3/context.json",
   "id": "https://raw.githubusercontent.com/BrumfieldLabs/cookbook-recipes/master/recipe/0103-poetry-reading-annotations/annopage/p1",
   "type": "AnnotationPage",
-  "items": [
+  "items": 
+  [
    { 
       "@context":"http://www.w3.org/ns/anno.jsonld",
       "id":"https://raw.githubusercontent.com/BrumfieldLabs/cookbook-recipes/master/recipe/0103-poetry-reading-annotations/manifest/canvas/annotation1",
@@ -20,6 +21,24 @@
             "t":"27.660653"
          }
       }
-   }
-   ]
+   },
+  {
+    "@context": "http://www.w3.org/ns/anno.jsonld",
+    "id": "https://raw.githubusercontent.com/BrumfieldLabs/cookbook-recipes/master/recipe/0103-poetry-reading-annotations/manifest/canvas/segment1/annotation/4",
+    "type": "Annotation",
+    "motivation": "commenting",
+    "body": {
+      "type": "TextualBody",
+      "value": "her kind",
+      "format": "text/plain"
+    },
+    "target": {
+      "source": "https://raw.githubusercontent.com/BrumfieldLabs/cookbook-recipes/master/recipe/0103-poetry-reading-annotations/manifest/canvas/segment1",
+      "selector": {
+        "type": "RangeSelector",
+        "t": "46.734653,47.875068"
+      }
+    }
+  }
+ ]
 }

--- a/recipe/0103-poetry-reading-annotations/annotations.json
+++ b/recipe/0103-poetry-reading-annotations/annotations.json
@@ -1,12 +1,15 @@
+---
+layout: null
+---
 {
   "@context": "http://iiif.io/api/presentation/3/context.json",
-  "id": "https://raw.githubusercontent.com/BrumfieldLabs/cookbook-recipes/master/recipe/0103-poetry-reading-annotations/annopage/p1",
+  "id": "{{site.url}}{{site.baseurl}}/{{page.path}}/annopage/p1",
   "type": "AnnotationPage",
   "items": 
   [
    { 
       "@context":"http://www.w3.org/ns/anno.jsonld",
-      "id":"https://raw.githubusercontent.com/BrumfieldLabs/cookbook-recipes/master/recipe/0103-poetry-reading-annotations/manifest/canvas/annotation1",
+      "id":"{{site.url}}{{site.baseurl}}/{{page.path}}/canvas/annotation1",
       "type":"Annotation",
       "motivation":"commenting",
       "body":{ 
@@ -15,7 +18,7 @@
          "format":"text/plain"
       },
       "target":{ 
-         "source":"https://raw.githubusercontent.com/BrumfieldLabs/cookbook-recipes/master/recipe/0103-poetry-reading-annotations/manifest/canvas/segment1",
+         "source":"{{site.url}}{{site.baseurl}}/{{page.path}}/canvas/segment1",
          "selector":{ 
             "type":"PointSelector",
             "t":"27.660653"
@@ -24,7 +27,7 @@
    },
   {
     "@context": "http://www.w3.org/ns/anno.jsonld",
-    "id": "https://raw.githubusercontent.com/BrumfieldLabs/cookbook-recipes/master/recipe/0103-poetry-reading-annotations/manifest/canvas/segment1/annotation/4",
+    "id": "{{site.url}}{{site.baseurl}}/{{page.path}}/canvas/segment1/annotation/4",
     "type": "Annotation",
     "motivation": "commenting",
     "body": {
@@ -33,7 +36,7 @@
       "format": "text/plain"
     },
     "target": {
-      "source": "https://raw.githubusercontent.com/BrumfieldLabs/cookbook-recipes/master/recipe/0103-poetry-reading-annotations/manifest/canvas/segment1",
+      "source": "{{site.url}}{{site.baseurl}}/{{page.path}}/canvas/segment1",
       "selector": {
         "type": "RangeSelector",
         "t": "46.734653,47.875068"

--- a/recipe/0103-poetry-reading-annotations/annotations.json
+++ b/recipe/0103-poetry-reading-annotations/annotations.json
@@ -1,0 +1,25 @@
+{
+  "@context": "http://iiif.io/api/presentation/3/context.json",
+  "id": "https://raw.githubusercontent.com/BrumfieldLabs/cookbook-recipes/master/recipe/0103-poetry-reading-annotations/annopage/p1",
+  "type": "AnnotationPage",
+  "items": [
+   { 
+      "@context":"http://www.w3.org/ns/anno.jsonld",
+      "id":"https://raw.githubusercontent.com/BrumfieldLabs/cookbook-recipes/master/recipe/0103-poetry-reading-annotations/manifest/canvas/annotation1",
+      "type":"Annotation",
+      "motivation":"commenting",
+      "body":{ 
+         "type":"TextualBody",
+         "value":"breath",
+         "format":"text/plain"
+      },
+      "target":{ 
+         "source":"https://raw.githubusercontent.com/BrumfieldLabs/cookbook-recipes/master/recipe/0103-poetry-reading-annotations/manifest/canvas/segment1",
+         "selector":{ 
+            "type":"PointSelector",
+            "t":"27.660653"
+         }
+      }
+   }
+   ]
+}

--- a/recipe/0103-poetry-reading-annotations/index.md
+++ b/recipe/0103-poetry-reading-annotations/index.md
@@ -29,7 +29,7 @@ This recipe shows two variations of referencing annotations from within a manife
 
 ## Example
 
-A manifest for the poem "Her Kind" read by Anne Sexton in 1974.  The recording is 107 minutes long.  Annotations are included in the manifest and show both a point annotation (at a particular time) and a range annotation (covering a time range).  (For more on these annotations, see the [annotation.json file description.](#annotations))
+A manifest for the poem "Her Kind" read by Anne Sexton in 1974.  The recording is 107 seconds long.  Annotations are included in the manifest and show both a point annotation (at a particular time) and a range annotation (covering a time range).  (For more on these annotations, see the [annotation.json file description.](#annotations))
 
 {: .line-numbers data-src="manifest1.json" }
 ```json

--- a/recipe/0103-poetry-reading-annotations/index.md
+++ b/recipe/0103-poetry-reading-annotations/index.md
@@ -23,9 +23,14 @@ This implementation builds off of the [audio example][0002], but adds Web Annota
 
 ## Example
 
-Describe in prose and provide examples, e.g.: 
+A manifest for the poem "Her Kind" read by Anne Sexton in 1974.  The recording is 107 minutes long.
 
 {: .line-numbers data-src="manifest.json" }
+```json
+```
+Annotation examples, both a point annotation (at a particular time) and a range annotation (covering a time range)
+
+{: .line-numbers data-src="annotations.json" }
 ```json
 ```
 

--- a/recipe/0103-poetry-reading-annotations/index.md
+++ b/recipe/0103-poetry-reading-annotations/index.md
@@ -1,0 +1,40 @@
+---
+title: Annotating a Poetry Reading
+id: 103
+layout: recipe
+tags: [audio, presentation, annotation]
+summary: "Use annotations to indicate aspects of the performance of a particular poem."
+---
+
+
+## Use Case
+
+While an audio file of a poetry performance may be divided into a track for each poem, scholars may wish to use annotations to indicate aspects of the performance of a particular poem.  
+
+Examples of the kinds of information to be annotated may include the following:
+* structural information (introduction, title, stanzas)
+* points where the performer takes a breath
+* repeated phrases
+
+## Implementation notes
+
+This implementation builds off of the [audio example][0002], but adds Web Annotations.
+
+
+## Example
+
+Describe in prose and provide examples, e.g.: 
+
+{: .line-numbers data-src="manifest.json" }
+```json
+```
+
+# Related recipes
+
+* [Simple Manifest - Audio][0002]
+* [Transformation - WebVTT or OHMS XML to Annotations][0079]
+
+
+{% include acronyms.md %}
+{% include links.md %}
+

--- a/recipe/0103-poetry-reading-annotations/index.md
+++ b/recipe/0103-poetry-reading-annotations/index.md
@@ -11,24 +11,37 @@ summary: "Use annotations to indicate aspects of the performance of a particular
 
 While an audio file of a poetry performance may be divided into a track for each poem, scholars may wish to use annotations to indicate aspects of the performance of a particular poem.  
 
-Examples of the kinds of information to be annotated may include the following:
+A researcher might want to annotate the following types of information:
 * structural information (introduction, title, stanzas)
 * points where the performer takes a breath
 * repeated phrases
+
+Since annotations could be available at the same time the manifest is generated, or might be a separate process that references the item manifest, both scenarios are shown.
+
+There is a third use case where manifests are unaware of annotations on them, but the systems that display the item are aware of the annotations and pull them in, using the target block in the annotation.
 
 ## Implementation notes
 
 This implementation builds off of the [audio example][0002], but adds Web Annotations.
 
+This recipe shows two variations of referencing annotations from within a manifest.  The first has the annotations embedded within the manifest file.  The second has a reference to annotations in a separate file.
+
 
 ## Example
 
-A manifest for the poem "Her Kind" read by Anne Sexton in 1974.  The recording is 107 minutes long.
+A manifest for the poem "Her Kind" read by Anne Sexton in 1974.  The recording is 107 minutes long.  Annotations are included in the manifest and show both a point annotation (at a particular time) and a range annotation (covering a time range).  (For more on these annotations, see the [annotation.json file description.](#annotations))
 
-{: .line-numbers data-src="manifest.json" }
+{: .line-numbers data-src="manifest1.json" }
 ```json
 ```
-Annotation examples, both a point annotation (at a particular time) and a range annotation (covering a time range)
+
+The same manifest, but with a reference to annotations in a separate file.  The annotation file is included below the manifest. 
+
+{: .line-numbers data-src="manifest2.json" }
+```json
+```
+
+<a name="annotations"></a>Annotation examples, both a point annotation (at a particular time) and a range annotation (covering a time range).  We use the "supplementing" motivation because these annotations are derived from the audio file on the canvas and the "commenting" motivation because the annotations are a comment about the canvas.  Annotations must have "supplementing" as a motivation for any annotations derived from the items on the canvas.
 
 {: .line-numbers data-src="annotations.json" }
 ```json

--- a/recipe/0103-poetry-reading-annotations/index.md
+++ b/recipe/0103-poetry-reading-annotations/index.md
@@ -22,10 +22,36 @@ There is a third use case where manifests are unaware of annotations on them, bu
 
 ## Implementation notes
 
-This implementation builds off of the [audio example][0002], but adds Web Annotations.
+1. This implementation builds off of the [audio example][0002], but adds Web Annotations.
 
-This recipe shows two variations of referencing annotations from within a manifest.  The first has the annotations embedded within the manifest file.  The second has a reference to annotations in a separate file.
+2. This recipe shows two variations of referencing annotations from within a manifest.  The first has the annotations embedded within the manifest file.  The second has a reference to annotations in a separate file.
 
+3. Where we use "RangeSelector" for the annotation target, we could instead use a Media Fragment like "#t=1.23,2.23" appended to the canvas URL. Instead of "source" you'd condense it into the "target" field.  For example:
+
+```
+                "target": {
+                  "source": "http://localhost:4000/recipe/0103-poetry-reading-annotations/manifest1.json/canvas/segment1/canvas/segment1",
+                  "selector": {
+                    "type": "RangeSelector",
+                    "t": "46.734653,47.875068"
+                  }
+```
+
+Could become
+
+```
+                "target": "http://localhost:4000/recipe/0103-poetry-reading-annotations/manifest1.json/canvas/segment1/canvas/segment1#t=46.734653,47.875068"
+```
+
+Both are correct.
+
+4. While the IIIF Specification requires arrays for most values, the W3C Web Annotation Specification does not require arrays, so the following line: 
+
+`"motivation": "commenting",`
+
+is correct, but unusual for a IIIF resource.  It could also be expressed (and must be if there is more than one motivation) as follows:
+
+`"motivation": ["commenting"],`
 
 ## Example
 

--- a/recipe/0103-poetry-reading-annotations/manifest.json
+++ b/recipe/0103-poetry-reading-annotations/manifest.json
@@ -29,5 +29,14 @@
           }
         ]
       }    
+    ],
+    "homepage": [
+      {
+        "id": "https://library.harvard.edu/poetry/listeningbooth/poets/sexton.html",
+        "type": "Text",
+        "label": { "en": [ "Anne Sexton at the Woodberry Poetry Room" ] },
+        "format": "text/html",
+        "language": [ "en" ]
+      }
     ]
   }

--- a/recipe/0103-poetry-reading-annotations/manifest.json
+++ b/recipe/0103-poetry-reading-annotations/manifest.json
@@ -1,0 +1,8 @@
+{
+    "@context": [
+      "http://www.w3.org/ns/anno.jsonld",
+      "http://iiif.io/api/presentation/{{ page.major }}/context.json"
+    ],
+    "id": "https://example.org/iiif/book1/manifest",
+    "type": "Manifest" 
+  }

--- a/recipe/0103-poetry-reading-annotations/manifest.json
+++ b/recipe/0103-poetry-reading-annotations/manifest.json
@@ -1,8 +1,33 @@
 {
-    "@context": [
-      "http://www.w3.org/ns/anno.jsonld",
-      "http://iiif.io/api/presentation/{{ page.major }}/context.json"
-    ],
-    "id": "https://example.org/iiif/book1/manifest",
-    "type": "Manifest" 
+    "@context": "http://iiif.io/api/presentation/3/context.json",
+    "id": "https://example.org/iiif/annsexton1974herkind/manifest",
+    "type": "Manifest",
+    "label": { "en": [ "Anne Sexton, Poetry Reading, 1974 -- Her Kind" ] },
+    "items": [
+      {
+        "id": "https://example.org/iiif/annsexton1974herkind/canvas/segment1",
+        "type": "Canvas",
+        "duration": 107,
+        "items": [
+          {
+            "id": "https://example.org/iiif/annsexton1974herkind/annotation/segment1/page",
+            "type": "AnnotationPage",
+            "items": [
+              {
+                "id": "https://example.org/iiif/annsexton1974herkind/annotation/segment1-audio",
+                "type": "Annotation",
+                "motivation": "painting",
+                "body": {
+                  "id": "https://library.harvard.edu/poetry/audio/listeningbooth//PS3537E915A6x1974/Her_Kind.mp3",
+                  "type": "Sound",
+                  "format": "audio/mp3",
+                  "duration": 107
+                },
+                "target": "https://example.org/iiif/annsexton1974herkind/canvas/segment1"
+              }
+            ]
+          }
+        ]
+      }    
+    ]
   }

--- a/recipe/0103-poetry-reading-annotations/manifest.json
+++ b/recipe/0103-poetry-reading-annotations/manifest.json
@@ -1,6 +1,6 @@
 {
     "@context": "http://iiif.io/api/presentation/3/context.json",
-    "id": "https://raw.githubusercontent.com/BrumfieldLabs/cookbook-recipes/master/recipe/0103-poetry-reading-annotations/manifest",
+    "id": "https://raw.githubusercontent.com/BrumfieldLabs/cookbook-recipes/master/recipe/0103-poetry-reading-annotations/manifest.json",
     "type": "Manifest",
     "label": { "en": [ "Anne Sexton, Poetry Reading, 1974 -- Her Kind" ] },
     "items": [

--- a/recipe/0103-poetry-reading-annotations/manifest.json
+++ b/recipe/0103-poetry-reading-annotations/manifest.json
@@ -1,6 +1,6 @@
 {
     "@context": "http://iiif.io/api/presentation/3/context.json",
-    "id": "https://raw.githubusercontent.com/BrumfieldLabs/cookbook-recipes/master/recipe/0103-poetry-reading-annotations/manifest"
+    "id": "https://raw.githubusercontent.com/BrumfieldLabs/cookbook-recipes/master/recipe/0103-poetry-reading-annotations/manifest.json"
     "type": "Manifest",
     "label": { "en": [ "Anne Sexton, Poetry Reading, 1974 -- Her Kind" ] },
     "items": [

--- a/recipe/0103-poetry-reading-annotations/manifest.json
+++ b/recipe/0103-poetry-reading-annotations/manifest.json
@@ -1,20 +1,20 @@
 {
     "@context": "http://iiif.io/api/presentation/3/context.json",
-    "id": "https://example.org/iiif/annsexton1974herkind/manifest",
+    "id": "https://raw.githubusercontent.com/BrumfieldLabs/cookbook-recipes/master/recipe/0103-poetry-reading-annotations/manifest"
     "type": "Manifest",
     "label": { "en": [ "Anne Sexton, Poetry Reading, 1974 -- Her Kind" ] },
     "items": [
       {
-        "id": "https://example.org/iiif/annsexton1974herkind/canvas/segment1",
+        "id": "https://raw.githubusercontent.com/BrumfieldLabs/cookbook-recipes/master/recipe/0103-poetry-reading-annotations/manifest/canvas/segment1",
         "type": "Canvas",
         "duration": 107,
         "items": [
           {
-            "id": "https://example.org/iiif/annsexton1974herkind/annotation/segment1/page",
+            "id": "https://raw.githubusercontent.com/BrumfieldLabs/cookbook-recipes/master/recipe/0103-poetry-reading-annotations/manifest/annotation/segment1/page",
             "type": "AnnotationPage",
             "items": [
               {
-                "id": "https://example.org/iiif/annsexton1974herkind/annotation/segment1-audio",
+                "id": "https://raw.githubusercontent.com/BrumfieldLabs/cookbook-recipes/master/recipe/0103-poetry-reading-annotations/manifest/annotation/segment1-audio",
                 "type": "Annotation",
                 "motivation": "painting",
                 "body": {
@@ -23,7 +23,7 @@
                   "format": "audio/mp3",
                   "duration": 107
                 },
-                "target": "https://example.org/iiif/annsexton1974herkind/canvas/segment1"
+                "target": "https://raw.githubusercontent.com/BrumfieldLabs/cookbook-recipes/master/recipe/0103-poetry-reading-annotations/manifest/canvas/segment1"
               }
             ]
           }

--- a/recipe/0103-poetry-reading-annotations/manifest.json
+++ b/recipe/0103-poetry-reading-annotations/manifest.json
@@ -1,6 +1,6 @@
 {
     "@context": "http://iiif.io/api/presentation/3/context.json",
-    "id": "https://raw.githubusercontent.com/BrumfieldLabs/cookbook-recipes/master/recipe/0103-poetry-reading-annotations/manifest.json"
+    "id": "https://raw.githubusercontent.com/BrumfieldLabs/cookbook-recipes/master/recipe/0103-poetry-reading-annotations/manifest",
     "type": "Manifest",
     "label": { "en": [ "Anne Sexton, Poetry Reading, 1974 -- Her Kind" ] },
     "items": [

--- a/recipe/0103-poetry-reading-annotations/manifest1.json
+++ b/recipe/0103-poetry-reading-annotations/manifest1.json
@@ -1,0 +1,86 @@
+{
+    "@context": "http://iiif.io/api/presentation/3/context.json",
+    "id": "https://raw.githubusercontent.com/BrumfieldLabs/cookbook-recipes/master/recipe/0103-poetry-reading-annotations/manifest.json",
+    "type": "Manifest",
+    "label": { "en": [ "Anne Sexton, Poetry Reading, 1974 -- Her Kind" ] },
+    "items": [
+      {
+        "id": "https://raw.githubusercontent.com/BrumfieldLabs/cookbook-recipes/master/recipe/0103-poetry-reading-annotations/manifest/canvas/segment1",
+        "type": "Canvas",
+        "duration": 107,
+        "items": [
+          {
+            "id": "https://raw.githubusercontent.com/BrumfieldLabs/cookbook-recipes/master/recipe/0103-poetry-reading-annotations/manifest/annotation/segment1/page",
+            "type": "AnnotationPage",
+            "items": [
+              {
+                "id": "https://raw.githubusercontent.com/BrumfieldLabs/cookbook-recipes/master/recipe/0103-poetry-reading-annotations/manifest/annotation/segment1-audio",
+                "type": "Annotation",
+                "motivation": "painting",
+                "body": {
+                  "id": "https://library.harvard.edu/poetry/audio/listeningbooth//PS3537E915A6x1974/Her_Kind.mp3",
+                  "type": "Sound",
+                  "format": "audio/mp3",
+                  "duration": 107
+                },
+                "target": "https://raw.githubusercontent.com/BrumfieldLabs/cookbook-recipes/master/recipe/0103-poetry-reading-annotations/manifest/canvas/segment1"
+              }
+            ]
+          }
+        ]
+      }    
+    ],
+    "annotations": [
+      {
+        "id": "https://raw.githubusercontent.com/BrumfieldLabs/cookbook-recipes/master/recipe/0103-poetry-reading-annotations/annotations.json",
+        "type": "AnnotationPage",
+        "items":   [
+		   { 
+		      "@context":"http://www.w3.org/ns/anno.jsonld",
+		      "id":"https://raw.githubusercontent.com/BrumfieldLabs/cookbook-recipes/master/recipe/0103-poetry-reading-annotations/manifest/canvas/annotation1",
+		      "type":"Annotation",
+		      "motivation":"commenting",
+		      "body":{ 
+		         "type":"TextualBody",
+		         "value":"breath",
+		         "format":"text/plain"
+		      },
+		      "target":{ 
+		         "source":"https://raw.githubusercontent.com/BrumfieldLabs/cookbook-recipes/master/recipe/0103-poetry-reading-annotations/manifest/canvas/segment1",
+		         "selector":{ 
+		            "type":"PointSelector",
+		            "t":"27.660653"
+		         }
+		      }
+		   },
+		  {
+		    "@context": "http://www.w3.org/ns/anno.jsonld",
+		    "id": "https://raw.githubusercontent.com/BrumfieldLabs/cookbook-recipes/master/recipe/0103-poetry-reading-annotations/manifest/canvas/segment1/annotation/4",
+		    "type": "Annotation",
+		    "motivation": "commenting",
+		    "body": {
+		      "type": "TextualBody",
+		      "value": "her kind",
+		      "format": "text/plain"
+		    },
+		    "target": {
+		      "source": "https://raw.githubusercontent.com/BrumfieldLabs/cookbook-recipes/master/recipe/0103-poetry-reading-annotations/manifest/canvas/segment1",
+		      "selector": {
+		        "type": "RangeSelector",
+		        "t": "46.734653,47.875068"
+		      }
+		    }
+		  }
+		 ]
+      }
+  	],
+    "homepage": [
+      {
+        "id": "https://library.harvard.edu/poetry/listeningbooth/poets/sexton.html",
+        "type": "Text",
+        "label": { "en": [ "Anne Sexton at the Woodberry Poetry Room" ] },
+        "format": "text/html",
+        "language": [ "en" ]
+      }
+    ]
+  }

--- a/recipe/0103-poetry-reading-annotations/manifest1.json
+++ b/recipe/0103-poetry-reading-annotations/manifest1.json
@@ -1,20 +1,23 @@
+---
+layout: null
+---
 {
     "@context": "http://iiif.io/api/presentation/3/context.json",
-    "id": "https://raw.githubusercontent.com/BrumfieldLabs/cookbook-recipes/master/recipe/0103-poetry-reading-annotations/manifest.json",
+    "id": "{{site.url}}{{site.basurl}}/{{page.path}}",
     "type": "Manifest",
     "label": { "en": [ "Anne Sexton, Poetry Reading, 1974 -- Her Kind" ] },
     "items": [
       {
-        "id": "https://raw.githubusercontent.com/BrumfieldLabs/cookbook-recipes/master/recipe/0103-poetry-reading-annotations/manifest/canvas/segment1",
+        "id": "{{site.url}}{{site.baseurl}}/{{page.path}}/canvas/segment1/canvas/segment1",
         "type": "Canvas",
         "duration": 107,
         "items": [
           {
-            "id": "https://raw.githubusercontent.com/BrumfieldLabs/cookbook-recipes/master/recipe/0103-poetry-reading-annotations/manifest/annotation/segment1/page",
+            "id": "{{site.url}}{{site.baseurl}}/{{page.path}}/canvas/segment1/annotation/segment1/page",
             "type": "AnnotationPage",
             "items": [
               {
-                "id": "https://raw.githubusercontent.com/BrumfieldLabs/cookbook-recipes/master/recipe/0103-poetry-reading-annotations/manifest/annotation/segment1-audio",
+                "id": "{{site.url}}{{site.baseurl}}/{{page.path}}/canvas/segment1/annotation/segment1-audio",
                 "type": "Annotation",
                 "motivation": "painting",
                 "body": {
@@ -23,57 +26,57 @@
                   "format": "audio/mp3",
                   "duration": 107
                 },
-                "target": "https://raw.githubusercontent.com/BrumfieldLabs/cookbook-recipes/master/recipe/0103-poetry-reading-annotations/manifest/canvas/segment1"
+                "target": "{{site.url}}{{site.baseurl}}/{{page.path}}/canvas/segment1/canvas/segment1"
+              },
+            ],
+            "annotations": [
+              {
+                "id": "https://raw.githubusercontent.com/BrumfieldLabs/cookbook-recipes/master/recipe/0103-poetry-reading-annotations/annotations.json",
+                "type": "AnnotationPage",
+                "items":   [
+               { 
+                  "@context":"http://www.w3.org/ns/anno.jsonld",
+                  "id":"{{site.url}}{{site.baseurl}}/{{page.path}}/canvas/segment1/canvas/annotation1",
+                  "type":"Annotation",
+                  "motivation":"commenting",
+                  "body":{ 
+                     "type":"TextualBody",
+                     "value":"breath",
+                     "format":"text/plain"
+                  },
+                  "target":{ 
+                     "source":"{{site.url}}{{site.baseurl}}/{{page.path}}/canvas/segment1/canvas/segment1",
+                     "selector":{ 
+                        "type":"PointSelector",
+                        "t":"27.660653"
+                     }
+                  }
+               },
+              {
+                "@context": "http://www.w3.org/ns/anno.jsonld",
+                "id": "{{site.url}}{{site.baseurl}}/{{page.path}}/canvas/segment1/canvas/segment1/annotation/4",
+                "type": "Annotation",
+                "motivation": "commenting",
+                "body": {
+                  "type": "TextualBody",
+                  "value": "her kind",
+                  "format": "text/plain"
+                },
+                "target": {
+                  "source": "{{site.url}}{{site.baseurl}}/{{page.path}}/canvas/segment1/canvas/segment1",
+                  "selector": {
+                    "type": "RangeSelector",
+                    "t": "46.734653,47.875068"
+                  }
+                }
+              }
+             ]
               }
             ]
           }
         ]
       }    
     ],
-    "annotations": [
-      {
-        "id": "https://raw.githubusercontent.com/BrumfieldLabs/cookbook-recipes/master/recipe/0103-poetry-reading-annotations/annotations.json",
-        "type": "AnnotationPage",
-        "items":   [
-		   { 
-		      "@context":"http://www.w3.org/ns/anno.jsonld",
-		      "id":"https://raw.githubusercontent.com/BrumfieldLabs/cookbook-recipes/master/recipe/0103-poetry-reading-annotations/manifest/canvas/annotation1",
-		      "type":"Annotation",
-		      "motivation":"commenting",
-		      "body":{ 
-		         "type":"TextualBody",
-		         "value":"breath",
-		         "format":"text/plain"
-		      },
-		      "target":{ 
-		         "source":"https://raw.githubusercontent.com/BrumfieldLabs/cookbook-recipes/master/recipe/0103-poetry-reading-annotations/manifest/canvas/segment1",
-		         "selector":{ 
-		            "type":"PointSelector",
-		            "t":"27.660653"
-		         }
-		      }
-		   },
-		  {
-		    "@context": "http://www.w3.org/ns/anno.jsonld",
-		    "id": "https://raw.githubusercontent.com/BrumfieldLabs/cookbook-recipes/master/recipe/0103-poetry-reading-annotations/manifest/canvas/segment1/annotation/4",
-		    "type": "Annotation",
-		    "motivation": "commenting",
-		    "body": {
-		      "type": "TextualBody",
-		      "value": "her kind",
-		      "format": "text/plain"
-		    },
-		    "target": {
-		      "source": "https://raw.githubusercontent.com/BrumfieldLabs/cookbook-recipes/master/recipe/0103-poetry-reading-annotations/manifest/canvas/segment1",
-		      "selector": {
-		        "type": "RangeSelector",
-		        "t": "46.734653,47.875068"
-		      }
-		    }
-		  }
-		 ]
-      }
-  	],
     "homepage": [
       {
         "id": "https://library.harvard.edu/poetry/listeningbooth/poets/sexton.html",

--- a/recipe/0103-poetry-reading-annotations/manifest1.json
+++ b/recipe/0103-poetry-reading-annotations/manifest1.json
@@ -2,88 +2,98 @@
 layout: null
 ---
 {
-    "@context": "http://iiif.io/api/presentation/3/context.json",
-    "id": "{{site.url}}{{site.basurl}}/{{page.path}}",
-    "type": "Manifest",
-    "label": { "en": [ "Anne Sexton, Poetry Reading, 1974 -- Her Kind" ] },
-    "items": [
-      {
-        "id": "{{site.url}}{{site.baseurl}}/{{page.path}}/canvas/segment1/canvas/segment1",
-        "type": "Canvas",
-        "duration": 107,
-        "items": [
-          {
-            "id": "{{site.url}}{{site.baseurl}}/{{page.path}}/canvas/segment1/annotation/segment1/page",
-            "type": "AnnotationPage",
-            "items": [
-              {
-                "id": "{{site.url}}{{site.baseurl}}/{{page.path}}/canvas/segment1/annotation/segment1-audio",
-                "type": "Annotation",
-                "motivation": "painting",
-                "body": {
-                  "id": "https://library.harvard.edu/poetry/audio/listeningbooth//PS3537E915A6x1974/Her_Kind.mp3",
-                  "type": "Sound",
-                  "format": "audio/mp3",
-                  "duration": 107
-                },
-                "target": "{{site.url}}{{site.baseurl}}/{{page.path}}/canvas/segment1/canvas/segment1"
+  "@context":"http://iiif.io/api/presentation/3/context.json",
+  "id":"{{site.url}}{{site.basurl}}/{{page.path}}",
+  "type":"Manifest",
+  "label":{
+    "en":[
+      "Anne Sexton, Poetry Reading, 1974 -- Her Kind"
+    ]
+  },
+  "items":[
+    {
+      "id":"{{site.url}}{{site.baseurl}}{{page.dir}}canvas/1",
+      "type":"Canvas",
+      "duration":107,
+      "items":[
+        {
+          "id":"{{site.url}}{{site.baseurl}}{{page.dir}}canvas/1/paintings",
+          "type":"AnnotationPage",
+          "items":[
+            {
+              "id":"{{site.url}}{{site.baseurl}}{{page.dir}}canvas/1/painting/1",
+              "type":"Annotation",
+              "motivation":"painting",
+              "body":{
+                "id":"https://library.harvard.edu/poetry/audio/listeningbooth//PS3537E915A6x1974/Her_Kind.mp3",
+                "type":"Sound",
+                "format":"audio/mp3",
+                "duration":107
               },
-            ],
-            "annotations": [
-              {
-                "id": "https://raw.githubusercontent.com/BrumfieldLabs/cookbook-recipes/master/recipe/0103-poetry-reading-annotations/annotations.json",
-                "type": "AnnotationPage",
-                "items":   [
-               { 
+              "target":"{{site.url}}{{site.baseurl}}{{page.dir}}canvas/1"
+            }
+          ],
+          "annotations":[
+            {
+              "id":"{{site.url}}{{site.baseurl}}{{page.dir}}annotations.json",
+              "type":"AnnotationPage",
+              "items":[
+                {
                   "@context":"http://www.w3.org/ns/anno.jsonld",
-                  "id":"{{site.url}}{{site.baseurl}}/{{page.path}}/canvas/segment1/canvas/annotation1",
+                  "id":"{{site.url}}{{site.baseurl}}{{page.dir}}canvas/1/annotation/1",
                   "type":"Annotation",
                   "motivation":"commenting",
-                  "body":{ 
-                     "type":"TextualBody",
-                     "value":"breath",
-                     "format":"text/plain"
+                  "body":{
+                    "type":"TextualBody",
+                    "value":"breath",
+                    "format":"text/plain"
                   },
-                  "target":{ 
-                     "source":"{{site.url}}{{site.baseurl}}/{{page.path}}/canvas/segment1/canvas/segment1",
-                     "selector":{ 
-                        "type":"PointSelector",
-                        "t":"27.660653"
-                     }
+                  "target":{
+                    "source":"{{site.url}}{{site.baseurl}}{{page.dir}}canvas/1",
+                    "selector":{
+                      "type":"PointSelector",
+                      "t":"27.660653"
+                    }
                   }
-               },
-              {
-                "@context": "http://www.w3.org/ns/anno.jsonld",
-                "id": "{{site.url}}{{site.baseurl}}/{{page.path}}/canvas/segment1/canvas/segment1/annotation/4",
-                "type": "Annotation",
-                "motivation": "commenting",
-                "body": {
-                  "type": "TextualBody",
-                  "value": "her kind",
-                  "format": "text/plain"
                 },
-                "target": {
-                  "source": "{{site.url}}{{site.baseurl}}/{{page.path}}/canvas/segment1/canvas/segment1",
-                  "selector": {
-                    "type": "RangeSelector",
-                    "t": "46.734653,47.875068"
+                {
+                  "@context":"http://www.w3.org/ns/anno.jsonld",
+                  "id":"{{site.url}}{{site.baseurl}}{{page.dir}}canvas/1/annotation/2",
+                  "type":"Annotation",
+                  "motivation":"commenting",
+                  "body":{
+                    "type":"TextualBody",
+                    "value":"her kind",
+                    "format":"text/plain"
+                  },
+                  "target":{
+                    "source":"{{site.url}}{{site.baseurl}}{{page.dir}}canvas/1",
+                    "selector":{
+                      "type":"RangeSelector",
+                      "t":"46.734653,47.875068"
+                    }
                   }
                 }
-              }
-             ]
-              }
-            ]
-          }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "homepage":[
+    {
+      "id":"https://library.harvard.edu/poetry/listeningbooth/poets/sexton.html",
+      "type":"Text",
+      "label":{
+        "en":[
+          "Anne Sexton at the Woodberry Poetry Room"
         ]
-      }    
-    ],
-    "homepage": [
-      {
-        "id": "https://library.harvard.edu/poetry/listeningbooth/poets/sexton.html",
-        "type": "Text",
-        "label": { "en": [ "Anne Sexton at the Woodberry Poetry Room" ] },
-        "format": "text/html",
-        "language": [ "en" ]
-      }
-    ]
-  }
+      },
+      "format":"text/html",
+      "language":[
+        "en"
+      ]
+    }
+  ]
+}

--- a/recipe/0103-poetry-reading-annotations/manifest2.json
+++ b/recipe/0103-poetry-reading-annotations/manifest2.json
@@ -30,6 +30,12 @@
         ]
       }    
     ],
+    "annotations": [
+      {
+        "id": "https://raw.githubusercontent.com/BrumfieldLabs/cookbook-recipes/master/recipe/0103-poetry-reading-annotations/annotations.json",
+        "type": "AnnotationPage",
+      }
+  	],
     "homepage": [
       {
         "id": "https://library.harvard.edu/poetry/listeningbooth/poets/sexton.html",

--- a/recipe/0103-poetry-reading-annotations/manifest2.json
+++ b/recipe/0103-poetry-reading-annotations/manifest2.json
@@ -1,9 +1,6 @@
 ---
 layout: null
 ---
----
-layout: null
----
 {
     "@context": "http://iiif.io/api/presentation/3/context.json",
     "id": "{{site.url}}{{site.basurl}}/{{page.path}}",

--- a/recipe/0103-poetry-reading-annotations/manifest2.json
+++ b/recipe/0103-poetry-reading-annotations/manifest2.json
@@ -1,23 +1,26 @@
 ---
 layout: null
 ---
+---
+layout: null
+---
 {
     "@context": "http://iiif.io/api/presentation/3/context.json",
-    "id": "{{site.url}}{{site.baseurl}}/{{page.path}}",
+    "id": "{{site.url}}{{site.basurl}}/{{page.path}}",
     "type": "Manifest",
     "label": { "en": [ "Anne Sexton, Poetry Reading, 1974 -- Her Kind" ] },
     "items": [
       {
-        "id": "{{site.url}}{{site.baseurl}}/{{page.path}}/canvas/segment1",
+        "id": "{{site.url}}{{site.baseurl}}{{page.dir}}canvas/1",
         "type": "Canvas",
         "duration": 107,
         "items": [
           {
-            "id": "{{site.url}}{{site.baseurl}}/{{page.path}}/annotation/segment1/page",
+            "id": "{{site.url}}{{site.baseurl}}{{page.dir}}canvas/1/paintings",
             "type": "AnnotationPage",
             "items": [
               {
-                "id": "{{site.url}}{{site.baseurl}}/{{page.path}}/annotation/segment1-audio",
+                "id": "{{site.url}}{{site.baseurl}}{{page.dir}}canvas/1/painting/1",
                 "type": "Annotation",
                 "motivation": "painting",
                 "body": {
@@ -26,19 +29,19 @@ layout: null
                   "format": "audio/mp3",
                   "duration": 107
                 },
-                "target": "{{site.url}}{{site.baseurl}}/{{page.path}}/canvas/segment1"
-              }
-            ]
-          }
-        ]
-      }    
+                "target": "{{site.url}}{{site.baseurl}}{{page.dir}}canvas/1"
+              },
+            ],
+          }    
+        ],
+      }
     ],
     "annotations": [
       {
-        "id": "https://raw.githubusercontent.com/BrumfieldLabs/cookbook-recipes/master/recipe/0103-poetry-reading-annotations/annotations.json",
+        "id": "{{site.url}}{{site.baseurl}}{{page.dir}}annotations.json",
         "type": "AnnotationPage",
       }
-  	],
+    ],
     "homepage": [
       {
         "id": "https://library.harvard.edu/poetry/listeningbooth/poets/sexton.html",

--- a/recipe/0103-poetry-reading-annotations/manifest2.json
+++ b/recipe/0103-poetry-reading-annotations/manifest2.json
@@ -1,20 +1,23 @@
+---
+layout: null
+---
 {
     "@context": "http://iiif.io/api/presentation/3/context.json",
-    "id": "https://raw.githubusercontent.com/BrumfieldLabs/cookbook-recipes/master/recipe/0103-poetry-reading-annotations/manifest.json",
+    "id": "{{site.url}}{{site.baseurl}}/{{page.path}}",
     "type": "Manifest",
     "label": { "en": [ "Anne Sexton, Poetry Reading, 1974 -- Her Kind" ] },
     "items": [
       {
-        "id": "https://raw.githubusercontent.com/BrumfieldLabs/cookbook-recipes/master/recipe/0103-poetry-reading-annotations/manifest/canvas/segment1",
+        "id": "{{site.url}}{{site.baseurl}}/{{page.path}}/canvas/segment1",
         "type": "Canvas",
         "duration": 107,
         "items": [
           {
-            "id": "https://raw.githubusercontent.com/BrumfieldLabs/cookbook-recipes/master/recipe/0103-poetry-reading-annotations/manifest/annotation/segment1/page",
+            "id": "{{site.url}}{{site.baseurl}}/{{page.path}}/annotation/segment1/page",
             "type": "AnnotationPage",
             "items": [
               {
-                "id": "https://raw.githubusercontent.com/BrumfieldLabs/cookbook-recipes/master/recipe/0103-poetry-reading-annotations/manifest/annotation/segment1-audio",
+                "id": "{{site.url}}{{site.baseurl}}/{{page.path}}/annotation/segment1-audio",
                 "type": "Annotation",
                 "motivation": "painting",
                 "body": {
@@ -23,7 +26,7 @@
                   "format": "audio/mp3",
                   "duration": 107
                 },
-                "target": "https://raw.githubusercontent.com/BrumfieldLabs/cookbook-recipes/master/recipe/0103-poetry-reading-annotations/manifest/canvas/segment1"
+                "target": "{{site.url}}{{site.baseurl}}/{{page.path}}/canvas/segment1"
               }
             ]
           }


### PR DESCRIPTION
An initial attempt at a IIIF v3 manifest with annotations on an audio file.

This needs to be updated with github pages references instead of raw github references to our repo, but I think that's a chicken & egg problem that will be fixed after merging (by whom?)

Discussion here or in the IIIF AV Slack channel.