### PR TITLE
Opera recipes

### DIFF
--- a/recipe/0026-toc-opera/index.md
+++ b/recipe/0026-toc-opera/index.md
@@ -15,9 +15,11 @@ An opera's table of contents can be hierarchically divided into acts, scenes, an
 
 Implementation is similar to [Book Chapters](../0024-toc-book-chapters/index.md) except that nesting may be deeper.
 
+Ranges in the structure target different portions of the same canvas using temporal Media Fragments (e.g. "t=0,100").  This is in contrast to the Book Chapters recipe where each range targets a different canvas.
+
 ## Restrictions
 
-None Known.
+The ranges here don’t overlap (although that is allowed in the spec) because that can affect the user experience of playing through all the ranges in a player (the overlapping part would be played twice).
 
 ## Example
 

--- a/recipe/0026-toc-opera/index.md
+++ b/recipe/0026-toc-opera/index.md
@@ -2,41 +2,33 @@
 title: Table of contents (ranges) - acts of an opera
 id: 26
 layout: recipe
-tags: [tbc]
-summary: "tbc"
+tags: [video, presentation, opera]
+summary: "Complex nested table of contents for an opera."
 ---
 
 
 ## Use Case
 
-Why is this pattern is important?
+An opera's table of contents can be hierarchically divided into acts, scenes, and arias.
 
 ## Implementation notes
 
-How does one implement the pattern?
+Implementation is similar to [Book Chapters](../0024-toc-book-chapters/index.md) except that nesting may be deeper.
 
 ## Restrictions
 
-When is this pattern is usable / not usable? Is it deprecated? If it uses multiple specifications, which versions are needed, etc.? (Not present if not needed.)
+None Known.
 
 ## Example
 
-Describe in prose and provide examples, e.g.: 
-
-``` json-doc
-{
-  "@context": [
-    "http://www.w3.org/ns/anno.jsonld",
-    "http://iiif.io/api/presentation/{{ page.major }}/context.json"
-  ],
-  "id": "https://example.org/iiif/book1/manifest",
-  "type": "Manifest" 
-}
-```
+{: .line-numbers data-download-link data-download-link-label="Download me" data-src="manifest.json" }
 
 # Related recipes
 
-Provide a bulleted list of related recipes and why they are relevant.
+* [Table of Contents (Ranges) - Book Chapters](../0024-toc-book-chapters/index.md)
+* [Simplest Manifest - Video](../0003-mvm-video/index.md)
+* [Opera One Canvas](../0064-opera-one-canvas/index.md) - The same opera from this example but expanded into a real world example.
+* [Opera Multiple Canvases](../0065-opera-multiple-canvases/index.md) - The same opera from this example but expanded into a real world example in audio format split across multiple canvases.
 
 
 {% include acronyms.md %}

--- a/recipe/0026-toc-opera/manifest.json
+++ b/recipe/0026-toc-opera/manifest.json
@@ -1,0 +1,465 @@
+{
+  "@context": [
+    "http://www.w3.org/ns/anno.jsonld",
+    "http://iiif.io/api/presentation/3/context.json"
+  ],
+  "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest",
+  "type": "Manifest",
+  "label": { "it": [ "L'elisir d'amore" ], "en": [ "The elixir of love" ] },
+  "items": [
+    {
+      "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/canvas/1",
+      "type": "Canvas",
+      "width": 1920,
+      "height": 1080,
+      "duration": 7278.422,
+      "items": [
+        {
+          "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/canvas/1/annotation_page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/canvas/1/annotation_page/1/annotation/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/canvas/1",
+              "body": {
+                "id": "https://iiif-av.s3.amazonaws.com/examples/indiana/donizetti-elixir/vae0637_accessH264_low.mp4",
+                "type": "Video",
+                "format": "video/mp4",
+                "height": 1080,
+                "width": 1920,
+                "duration": 7278.422
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "structures": [
+    {
+      "type": "Range",
+      "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/range/r9ad47417-1344-4991-a41a-b084c69a12d4",
+      "label": {
+        "en": [
+          "IU Opera Theatre"
+        ]
+      },
+      "items": [
+        {
+          "type": "Range",
+          "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/range/r764d8a04-47a4-4aa5-bc68-a572ad33866a",
+          "label": {
+            "en": [
+              "[ambience]"
+            ]
+          },
+          "items": [
+            {
+              "type": "Canvas",
+              "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/canvas/1#t=0.0,26.17"
+            }
+          ]
+        },
+        {
+          "type": "Range",
+          "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/range/raa6a9c5b-79be-4d73-a3fc-2cb22e9e6618",
+          "label": {
+            "it": [
+              "Gaetano Donizetti, L'Elisir D'Amore"
+            ]
+          },
+          "items": [
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/range/r2ceb895e-a290-43b6-9351-f1fc8bad336c",
+              "label": {
+                "it": [
+                  "Atto Primo – Preludio e Coro d'introduzione – Bel conforto al mietitore"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/canvas/1#t=26.17,302.05"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/range/r5061e574-e6c6-4e04-93ea-368f8afab78b",
+              "label": {
+                "it": [
+                  "Atto Primo – Cavatoma – Quanto é cara!"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/canvas/1#t=302.05,488.23"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/range/r2f07821a-33c0-49c3-8e28-2fa3bcdf1349",
+              "label": {
+                "it": [
+                  "Atto Primo – Cavatina - Benedette queste carte! – Della crudele Isotta"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/canvas/1#t=488.23,770.29"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/range/rf2a0a534-4e5f-4280-a572-0f6b4d64246d",
+              "label": {
+                "it": [
+                  "Atto Primo – Cavatina e Stretta d’introduzione – Come Paride vezzoso"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/canvas/1#t=770.29,1278.04"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/range/r40dee6f3-6df4-42cc-b71c-7536d26df61e",
+              "label": {
+                "it": [
+                  "Atto Primo – Recitativo – Intanto, o mia ragazza"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/canvas/1#t=1278.04,1314.05"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/range/rffadb10b-f45f-4f37-8566-cac50783f77c",
+              "label": {
+                "it": [
+                  "Atto Primo – Scene e Duetto – Una parola, o Adina – Chiedi all’aura lushinghiera"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/canvas/1#t=1314.05,1738.15"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/range/rf072516a-868d-4bf1-86b4-bba2951689ec",
+              "label": {
+                "it": [
+                  "Atto Primo – Coro – Che vuol dire codesta sonata?"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/canvas/1#t=1738.15,1855.24"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/range/r05fc5414-d4c9-416c-bb08-44aabde33a63",
+              "label": {
+                "it": [
+                  "Atto Primo – Cavatina – Udite, udite, o rustici"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/canvas/1#t=1855.24,2288.23"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/range/r60d2be49-2651-47da-9018-fb31758314ab",
+              "label": {
+                "it": [
+                  "Atto Primo – Recitavio, Scena e Duetto – Ardir! – Voglio dire"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/canvas/1#t=2288.23,2705.21"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/range/r23b13c8a-27d1-416f-ba25-f71a7947a0b7",
+              "label": {
+                "it": [
+                  "Atto Primo – Recitavio – Caro Elisir! sei mio!"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/canvas/1#t=2705.21,2847.14"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/range/r04634ffa-bf37-4537-80e4-cf0d7919666a",
+              "label": {
+                "it": [
+                  "Atto Primo – Scene e Duetto – Lallarallarà, la, la – Esulti pur la Barbara"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/canvas/1#t=2847.14,3174.16"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/range/r95c31349-5bc1-4c4f-8fc1-7ff4e34133dc",
+              "label": {
+                "it": [
+                  "Atto Primo – Terzetto – In Guerra ed in amore"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/canvas/1#t=3174.16,3370.2"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/range/re9d2963f-ed54-4ff8-9f0f-19e2be05bf0e",
+              "label": {
+                "it": [
+                  "Atto Primo – Quartetto e Stretta del Finale I – Signor sergente – Adina, credimi"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/canvas/1#t=3370.2,3971.24"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Range",
+          "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/range/r3e7e0b40-026d-43d0-8281-9e0dc11ae674",
+          "label": {
+            "en": [
+              "[ambience]"
+            ]
+          },
+          "items": [
+            {
+              "type": "Canvas",
+              "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/canvas/1#t=3971.24,4004.13"
+            }
+          ]
+        },
+        {
+          "type": "Range",
+          "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/range/rf7350bab-17b7-4b7d-858e-e8c83e8cef7a",
+          "label": {
+            "it": [
+              "Gaetano Donizetti, L'Elisir D'Amore"
+            ]
+          },
+          "items": [
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/range/rdedd2c01-86be-4f7b-bfcc-586848bb0cd0",
+              "label": {
+                "it": [
+                  "Atto Secondo – Coro d’Introduzione – Cantiamo, facciam brindisi"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/canvas/1#t=4004.13,4140.28"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/range/r00d145d8-7bd7-4077-be4c-247cc026c811",
+              "label": {
+                "it": [
+                  "Atto Secondo – Recitativo – Poiché cantar vi alletta"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/canvas/1#t=4140.28,4188.16"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/range/r1c7aa4ff-9200-475c-9df5-61618c0fec35",
+              "label": {
+                "it": [
+                  "Atto Secondo – Barcarola a due voci – Io son ricco e tu sei bella"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/canvas/1#t=4188.16,4331.02"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/range/rc31de5e6-0db6-4893-8383-af6fbf429f7a",
+              "label": {
+                "it": [
+                  "Atto Secondo – Recotativo – Silenzio! È qua il notaro"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/canvas/1#t=4331.02,4533.0"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/range/r97bfe0c8-0fed-4c8a-9412-fefec5c891fc",
+              "label": {
+                "it": [
+                  "Atto Secondo – Scena e Duetto – La donna è en animale stravagante – Venti scudi"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/canvas/1#t=4533.0,5019.12"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/range/r8e68d5c5-6931-4532-ac1b-212f437ce89b",
+              "label": {
+                "it": [
+                  "Atto Secondo – Coro – Saria possibil?"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/canvas/1#t=5019.12,5254.26"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/range/re14797a3-4222-4922-814a-a4fa12f989ea",
+              "label": {
+                "it": [
+                  "Atto Secondo – Quartetto – Dell’elisir mirabile"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/canvas/1#t=5254.26,5658.139999999999"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/range/re0591627-b002-4dec-a579-cc01b12b30d4",
+              "label": {
+                "it": [
+                  "Atto Secondo – Recitativo e Duetto – Come sen va contento! – Quanto amore!"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/canvas/1#t=5658.139999999999,6133.25"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/range/ra6cec2bb-4028-4f34-bcf5-3406d5252853",
+              "label": {
+                "it": [
+                  "Atto Secondo – Romanza – Una furtiva lagrima"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/canvas/1#t=6133.25,6412.27"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/range/r7ec19a5a-e1cc-4db1-ab96-0ad578b90cc9",
+              "label": {
+                "it": [
+                  "Atto Secondo – Recitativo ed Aria - Eccola – Prendi, Per me sei Libero"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/canvas/1#t=6412.27,6941.01"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/range/r2b320d47-3996-4901-9322-808583958672",
+              "label": {
+                "it": [
+                  "Atto Secondo – Recitativo – Aria e Finale II - Alto! – Fronte! – Eli corregge ogni difetto"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/canvas/1#t=6941.01,7278.0"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/recipe/0026-toc-opera/manifest.json
+++ b/recipe/0026-toc-opera/manifest.json
@@ -21,7 +21,7 @@
               "motivation": "painting",
               "target": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1",
               "body": {
-                "id": "https://iiif-av.s3.amazonaws.com/examples/indiana/donizetti-elixir/vae0637_accessH264_low.mp4",
+                "id": "https://fixtures.iiif.io/video/indiana/donizetti-elixir/vae0637_accessH264_low.mp4",
                 "type": "Video",
                 "format": "video/mp4",
                 "height": 1080,
@@ -46,25 +46,10 @@
       "items": [
         {
           "type": "Range",
-          "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r764d8a04-47a4-4aa5-bc68-a572ad33866a",
-          "label": {
-            "en": [
-              "[ambience]"
-            ]
-          },
-          "items": [
-            {
-              "type": "Canvas",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=0.0,26.17"
-            }
-          ]
-        },
-        {
-          "type": "Range",
           "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/raa6a9c5b-79be-4d73-a3fc-2cb22e9e6618",
           "label": {
             "it": [
-              "Gaetano Donizetti, L'Elisir D'Amore"
+              "Gaetano Donizetti, L'Elisir D'Amore, Atto Primo"
             ]
           },
           "items": [
@@ -73,13 +58,13 @@
               "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r2ceb895e-a290-43b6-9351-f1fc8bad336c",
               "label": {
                 "it": [
-                  "Atto Primo – Preludio e Coro d'introduzione – Bel conforto al mietitore"
+                  "Preludio e Coro d'introduzione – Bel conforto al mietitore"
                 ]
               },
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=26.17,302.05"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=0,302.05"
                 }
               ]
             },
@@ -87,196 +72,16 @@
               "type": "Range",
               "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r5061e574-e6c6-4e04-93ea-368f8afab78b",
               "label": {
-                "it": [
-                  "Atto Primo – Cavatoma – Quanto é cara!"
+                "en": [
+                  "Remainder of Act I"
                 ]
               },
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=302.05,488.23"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=302.05,3971.24"
                 }
               ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r2f07821a-33c0-49c3-8e28-2fa3bcdf1349",
-              "label": {
-                "it": [
-                  "Atto Primo – Cavatina - Benedette queste carte! – Della crudele Isotta"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=488.23,770.29"
-                }
-              ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/rf2a0a534-4e5f-4280-a572-0f6b4d64246d",
-              "label": {
-                "it": [
-                  "Atto Primo – Cavatina e Stretta d’introduzione – Come Paride vezzoso"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=770.29,1278.04"
-                }
-              ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r40dee6f3-6df4-42cc-b71c-7536d26df61e",
-              "label": {
-                "it": [
-                  "Atto Primo – Recitativo – Intanto, o mia ragazza"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=1278.04,1314.05"
-                }
-              ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/rffadb10b-f45f-4f37-8566-cac50783f77c",
-              "label": {
-                "it": [
-                  "Atto Primo – Scene e Duetto – Una parola, o Adina – Chiedi all’aura lushinghiera"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=1314.05,1738.15"
-                }
-              ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/rf072516a-868d-4bf1-86b4-bba2951689ec",
-              "label": {
-                "it": [
-                  "Atto Primo – Coro – Che vuol dire codesta sonata?"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=1738.15,1855.24"
-                }
-              ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r05fc5414-d4c9-416c-bb08-44aabde33a63",
-              "label": {
-                "it": [
-                  "Atto Primo – Cavatina – Udite, udite, o rustici"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=1855.24,2288.23"
-                }
-              ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r60d2be49-2651-47da-9018-fb31758314ab",
-              "label": {
-                "it": [
-                  "Atto Primo – Recitavio, Scena e Duetto – Ardir! – Voglio dire"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=2288.23,2705.21"
-                }
-              ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r23b13c8a-27d1-416f-ba25-f71a7947a0b7",
-              "label": {
-                "it": [
-                  "Atto Primo – Recitavio – Caro Elisir! sei mio!"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=2705.21,2847.14"
-                }
-              ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r04634ffa-bf37-4537-80e4-cf0d7919666a",
-              "label": {
-                "it": [
-                  "Atto Primo – Scene e Duetto – Lallarallarà, la, la – Esulti pur la Barbara"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=2847.14,3174.16"
-                }
-              ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r95c31349-5bc1-4c4f-8fc1-7ff4e34133dc",
-              "label": {
-                "it": [
-                  "Atto Primo – Terzetto – In Guerra ed in amore"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=3174.16,3370.2"
-                }
-              ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/re9d2963f-ed54-4ff8-9f0f-19e2be05bf0e",
-              "label": {
-                "it": [
-                  "Atto Primo – Quartetto e Stretta del Finale I – Signor sergente – Adina, credimi"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=3370.2,3971.24"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "Range",
-          "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r3e7e0b40-026d-43d0-8281-9e0dc11ae674",
-          "label": {
-            "en": [
-              "[ambience]"
-            ]
-          },
-          "items": [
-            {
-              "type": "Canvas",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=3971.24,4004.13"
             }
           ]
         },
@@ -285,174 +90,13 @@
           "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/rf7350bab-17b7-4b7d-858e-e8c83e8cef7a",
           "label": {
             "it": [
-              "Gaetano Donizetti, L'Elisir D'Amore"
+              "Gaetano Donizetti, L'Elisir D'Amore, Atto Secondo"
             ]
           },
           "items": [
             {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/rdedd2c01-86be-4f7b-bfcc-586848bb0cd0",
-              "label": {
-                "it": [
-                  "Atto Secondo – Coro d’Introduzione – Cantiamo, facciam brindisi"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=4004.13,4140.28"
-                }
-              ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r00d145d8-7bd7-4077-be4c-247cc026c811",
-              "label": {
-                "it": [
-                  "Atto Secondo – Recitativo – Poiché cantar vi alletta"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=4140.28,4188.16"
-                }
-              ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r1c7aa4ff-9200-475c-9df5-61618c0fec35",
-              "label": {
-                "it": [
-                  "Atto Secondo – Barcarola a due voci – Io son ricco e tu sei bella"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=4188.16,4331.02"
-                }
-              ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/rc31de5e6-0db6-4893-8383-af6fbf429f7a",
-              "label": {
-                "it": [
-                  "Atto Secondo – Recotativo – Silenzio! È qua il notaro"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=4331.02,4533.0"
-                }
-              ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r97bfe0c8-0fed-4c8a-9412-fefec5c891fc",
-              "label": {
-                "it": [
-                  "Atto Secondo – Scena e Duetto – La donna è en animale stravagante – Venti scudi"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=4533.0,5019.12"
-                }
-              ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r8e68d5c5-6931-4532-ac1b-212f437ce89b",
-              "label": {
-                "it": [
-                  "Atto Secondo – Coro – Saria possibil?"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=5019.12,5254.26"
-                }
-              ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/re14797a3-4222-4922-814a-a4fa12f989ea",
-              "label": {
-                "it": [
-                  "Atto Secondo – Quartetto – Dell’elisir mirabile"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=5254.26,5658.139999999999"
-                }
-              ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/re0591627-b002-4dec-a579-cc01b12b30d4",
-              "label": {
-                "it": [
-                  "Atto Secondo – Recitativo e Duetto – Come sen va contento! – Quanto amore!"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=5658.139999999999,6133.25"
-                }
-              ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/ra6cec2bb-4028-4f34-bcf5-3406d5252853",
-              "label": {
-                "it": [
-                  "Atto Secondo – Romanza – Una furtiva lagrima"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=6133.25,6412.27"
-                }
-              ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r7ec19a5a-e1cc-4db1-ab96-0ad578b90cc9",
-              "label": {
-                "it": [
-                  "Atto Secondo – Recitativo ed Aria - Eccola – Prendi, Per me sei Libero"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=6412.27,6941.01"
-                }
-              ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r2b320d47-3996-4901-9322-808583958672",
-              "label": {
-                "it": [
-                  "Atto Secondo – Recitativo – Aria e Finale II - Alto! – Fronte! – Eli corregge ogni difetto"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=6941.01,7278.0"
-                }
-              ]
+              "type": "Canvas",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=3971.24,7278.422"
             }
           ]
         }

--- a/recipe/0026-toc-opera/manifest.json
+++ b/recipe/0026-toc-opera/manifest.json
@@ -1,28 +1,25 @@
 {
-  "@context": [
-    "http://www.w3.org/ns/anno.jsonld",
-    "http://iiif.io/api/presentation/3/context.json"
-  ],
-  "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest",
+  "@context": "http://iiif.io/api/presentation/3/context.json",
+  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}",
   "type": "Manifest",
   "label": { "it": [ "L'elisir d'amore" ], "en": [ "The elixir of love" ] },
   "items": [
     {
-      "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/canvas/1",
+      "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1",
       "type": "Canvas",
       "width": 1920,
       "height": 1080,
       "duration": 7278.422,
       "items": [
         {
-          "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/canvas/1/annotation_page/1",
+          "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1/annotation_page/1",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/canvas/1/annotation_page/1/annotation/1",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1/annotation_page/1/annotation/1",
               "type": "Annotation",
               "motivation": "painting",
-              "target": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/canvas/1",
+              "target": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1",
               "body": {
                 "id": "https://iiif-av.s3.amazonaws.com/examples/indiana/donizetti-elixir/vae0637_accessH264_low.mp4",
                 "type": "Video",
@@ -40,7 +37,7 @@
   "structures": [
     {
       "type": "Range",
-      "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/range/r9ad47417-1344-4991-a41a-b084c69a12d4",
+      "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r9ad47417-1344-4991-a41a-b084c69a12d4",
       "label": {
         "en": [
           "IU Opera Theatre"
@@ -49,7 +46,7 @@
       "items": [
         {
           "type": "Range",
-          "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/range/r764d8a04-47a4-4aa5-bc68-a572ad33866a",
+          "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r764d8a04-47a4-4aa5-bc68-a572ad33866a",
           "label": {
             "en": [
               "[ambience]"
@@ -58,13 +55,13 @@
           "items": [
             {
               "type": "Canvas",
-              "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/canvas/1#t=0.0,26.17"
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=0.0,26.17"
             }
           ]
         },
         {
           "type": "Range",
-          "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/range/raa6a9c5b-79be-4d73-a3fc-2cb22e9e6618",
+          "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/raa6a9c5b-79be-4d73-a3fc-2cb22e9e6618",
           "label": {
             "it": [
               "Gaetano Donizetti, L'Elisir D'Amore"
@@ -73,7 +70,7 @@
           "items": [
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/range/r2ceb895e-a290-43b6-9351-f1fc8bad336c",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r2ceb895e-a290-43b6-9351-f1fc8bad336c",
               "label": {
                 "it": [
                   "Atto Primo – Preludio e Coro d'introduzione – Bel conforto al mietitore"
@@ -82,13 +79,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/canvas/1#t=26.17,302.05"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=26.17,302.05"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/range/r5061e574-e6c6-4e04-93ea-368f8afab78b",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r5061e574-e6c6-4e04-93ea-368f8afab78b",
               "label": {
                 "it": [
                   "Atto Primo – Cavatoma – Quanto é cara!"
@@ -97,13 +94,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/canvas/1#t=302.05,488.23"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=302.05,488.23"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/range/r2f07821a-33c0-49c3-8e28-2fa3bcdf1349",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r2f07821a-33c0-49c3-8e28-2fa3bcdf1349",
               "label": {
                 "it": [
                   "Atto Primo – Cavatina - Benedette queste carte! – Della crudele Isotta"
@@ -112,13 +109,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/canvas/1#t=488.23,770.29"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=488.23,770.29"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/range/rf2a0a534-4e5f-4280-a572-0f6b4d64246d",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/rf2a0a534-4e5f-4280-a572-0f6b4d64246d",
               "label": {
                 "it": [
                   "Atto Primo – Cavatina e Stretta d’introduzione – Come Paride vezzoso"
@@ -127,13 +124,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/canvas/1#t=770.29,1278.04"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=770.29,1278.04"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/range/r40dee6f3-6df4-42cc-b71c-7536d26df61e",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r40dee6f3-6df4-42cc-b71c-7536d26df61e",
               "label": {
                 "it": [
                   "Atto Primo – Recitativo – Intanto, o mia ragazza"
@@ -142,13 +139,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/canvas/1#t=1278.04,1314.05"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=1278.04,1314.05"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/range/rffadb10b-f45f-4f37-8566-cac50783f77c",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/rffadb10b-f45f-4f37-8566-cac50783f77c",
               "label": {
                 "it": [
                   "Atto Primo – Scene e Duetto – Una parola, o Adina – Chiedi all’aura lushinghiera"
@@ -157,13 +154,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/canvas/1#t=1314.05,1738.15"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=1314.05,1738.15"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/range/rf072516a-868d-4bf1-86b4-bba2951689ec",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/rf072516a-868d-4bf1-86b4-bba2951689ec",
               "label": {
                 "it": [
                   "Atto Primo – Coro – Che vuol dire codesta sonata?"
@@ -172,13 +169,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/canvas/1#t=1738.15,1855.24"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=1738.15,1855.24"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/range/r05fc5414-d4c9-416c-bb08-44aabde33a63",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r05fc5414-d4c9-416c-bb08-44aabde33a63",
               "label": {
                 "it": [
                   "Atto Primo – Cavatina – Udite, udite, o rustici"
@@ -187,13 +184,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/canvas/1#t=1855.24,2288.23"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=1855.24,2288.23"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/range/r60d2be49-2651-47da-9018-fb31758314ab",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r60d2be49-2651-47da-9018-fb31758314ab",
               "label": {
                 "it": [
                   "Atto Primo – Recitavio, Scena e Duetto – Ardir! – Voglio dire"
@@ -202,13 +199,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/canvas/1#t=2288.23,2705.21"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=2288.23,2705.21"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/range/r23b13c8a-27d1-416f-ba25-f71a7947a0b7",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r23b13c8a-27d1-416f-ba25-f71a7947a0b7",
               "label": {
                 "it": [
                   "Atto Primo – Recitavio – Caro Elisir! sei mio!"
@@ -217,13 +214,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/canvas/1#t=2705.21,2847.14"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=2705.21,2847.14"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/range/r04634ffa-bf37-4537-80e4-cf0d7919666a",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r04634ffa-bf37-4537-80e4-cf0d7919666a",
               "label": {
                 "it": [
                   "Atto Primo – Scene e Duetto – Lallarallarà, la, la – Esulti pur la Barbara"
@@ -232,13 +229,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/canvas/1#t=2847.14,3174.16"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=2847.14,3174.16"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/range/r95c31349-5bc1-4c4f-8fc1-7ff4e34133dc",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r95c31349-5bc1-4c4f-8fc1-7ff4e34133dc",
               "label": {
                 "it": [
                   "Atto Primo – Terzetto – In Guerra ed in amore"
@@ -247,13 +244,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/canvas/1#t=3174.16,3370.2"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=3174.16,3370.2"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/range/re9d2963f-ed54-4ff8-9f0f-19e2be05bf0e",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/re9d2963f-ed54-4ff8-9f0f-19e2be05bf0e",
               "label": {
                 "it": [
                   "Atto Primo – Quartetto e Stretta del Finale I – Signor sergente – Adina, credimi"
@@ -262,7 +259,7 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/canvas/1#t=3370.2,3971.24"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=3370.2,3971.24"
                 }
               ]
             }
@@ -270,7 +267,7 @@
         },
         {
           "type": "Range",
-          "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/range/r3e7e0b40-026d-43d0-8281-9e0dc11ae674",
+          "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r3e7e0b40-026d-43d0-8281-9e0dc11ae674",
           "label": {
             "en": [
               "[ambience]"
@@ -279,13 +276,13 @@
           "items": [
             {
               "type": "Canvas",
-              "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/canvas/1#t=3971.24,4004.13"
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=3971.24,4004.13"
             }
           ]
         },
         {
           "type": "Range",
-          "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/range/rf7350bab-17b7-4b7d-858e-e8c83e8cef7a",
+          "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/rf7350bab-17b7-4b7d-858e-e8c83e8cef7a",
           "label": {
             "it": [
               "Gaetano Donizetti, L'Elisir D'Amore"
@@ -294,7 +291,7 @@
           "items": [
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/range/rdedd2c01-86be-4f7b-bfcc-586848bb0cd0",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/rdedd2c01-86be-4f7b-bfcc-586848bb0cd0",
               "label": {
                 "it": [
                   "Atto Secondo – Coro d’Introduzione – Cantiamo, facciam brindisi"
@@ -303,13 +300,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/canvas/1#t=4004.13,4140.28"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=4004.13,4140.28"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/range/r00d145d8-7bd7-4077-be4c-247cc026c811",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r00d145d8-7bd7-4077-be4c-247cc026c811",
               "label": {
                 "it": [
                   "Atto Secondo – Recitativo – Poiché cantar vi alletta"
@@ -318,13 +315,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/canvas/1#t=4140.28,4188.16"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=4140.28,4188.16"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/range/r1c7aa4ff-9200-475c-9df5-61618c0fec35",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r1c7aa4ff-9200-475c-9df5-61618c0fec35",
               "label": {
                 "it": [
                   "Atto Secondo – Barcarola a due voci – Io son ricco e tu sei bella"
@@ -333,13 +330,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/canvas/1#t=4188.16,4331.02"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=4188.16,4331.02"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/range/rc31de5e6-0db6-4893-8383-af6fbf429f7a",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/rc31de5e6-0db6-4893-8383-af6fbf429f7a",
               "label": {
                 "it": [
                   "Atto Secondo – Recotativo – Silenzio! È qua il notaro"
@@ -348,13 +345,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/canvas/1#t=4331.02,4533.0"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=4331.02,4533.0"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/range/r97bfe0c8-0fed-4c8a-9412-fefec5c891fc",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r97bfe0c8-0fed-4c8a-9412-fefec5c891fc",
               "label": {
                 "it": [
                   "Atto Secondo – Scena e Duetto – La donna è en animale stravagante – Venti scudi"
@@ -363,13 +360,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/canvas/1#t=4533.0,5019.12"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=4533.0,5019.12"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/range/r8e68d5c5-6931-4532-ac1b-212f437ce89b",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r8e68d5c5-6931-4532-ac1b-212f437ce89b",
               "label": {
                 "it": [
                   "Atto Secondo – Coro – Saria possibil?"
@@ -378,13 +375,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/canvas/1#t=5019.12,5254.26"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=5019.12,5254.26"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/range/re14797a3-4222-4922-814a-a4fa12f989ea",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/re14797a3-4222-4922-814a-a4fa12f989ea",
               "label": {
                 "it": [
                   "Atto Secondo – Quartetto – Dell’elisir mirabile"
@@ -393,13 +390,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/canvas/1#t=5254.26,5658.139999999999"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=5254.26,5658.139999999999"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/range/re0591627-b002-4dec-a579-cc01b12b30d4",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/re0591627-b002-4dec-a579-cc01b12b30d4",
               "label": {
                 "it": [
                   "Atto Secondo – Recitativo e Duetto – Come sen va contento! – Quanto amore!"
@@ -408,13 +405,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/canvas/1#t=5658.139999999999,6133.25"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=5658.139999999999,6133.25"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/range/ra6cec2bb-4028-4f34-bcf5-3406d5252853",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/ra6cec2bb-4028-4f34-bcf5-3406d5252853",
               "label": {
                 "it": [
                   "Atto Secondo – Romanza – Una furtiva lagrima"
@@ -423,13 +420,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/canvas/1#t=6133.25,6412.27"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=6133.25,6412.27"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/range/r7ec19a5a-e1cc-4db1-ab96-0ad578b90cc9",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r7ec19a5a-e1cc-4db1-ab96-0ad578b90cc9",
               "label": {
                 "it": [
                   "Atto Secondo – Recitativo ed Aria - Eccola – Prendi, Per me sei Libero"
@@ -438,13 +435,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/canvas/1#t=6412.27,6941.01"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=6412.27,6941.01"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/range/r2b320d47-3996-4901-9322-808583958672",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r2b320d47-3996-4901-9322-808583958672",
               "label": {
                 "it": [
                   "Atto Secondo – Recitativo – Aria e Finale II - Alto! – Fronte! – Eli corregge ogni difetto"
@@ -453,7 +450,7 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0026-toc-opera/manifest/canvas/1#t=6941.01,7278.0"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=6941.01,7278.0"
                 }
               ]
             }

--- a/recipe/0064-opera-one-canvas/index.md
+++ b/recipe/0064-opera-one-canvas/index.md
@@ -2,42 +2,31 @@
 title: An opera on one Canvas
 id: 64
 layout: recipe
-tags: [tbc]
-summary: "tbc"
+tags: [video, presentation, opera]
+summary: "A real world example of a video recording of an opera on one canvas."
 ---
 
 
 ## Use Case
 
-Why is this pattern is important?
+Opera performances are generally long with lots of divisions, often hierarchical, making for a complex table of contents.  This real world example shows how this can be modeled using a single canvas.
 
 ## Implementation notes
 
-How does one implement the pattern?
+This implementation builds upon the [opera table of contents recipe](../0026-toc-opera/index.md) but adds metadata, homepage, and thumbnail properties for more more context.
 
 ## Restrictions
 
-When is this pattern is usable / not usable? Is it deprecated? If it uses multiple specifications, which versions are needed, etc.? (Not present if not needed.)
+None Known.
 
 ## Example
 
-Describe in prose and provide examples, e.g.: 
-
-``` json-doc
-{
-  "@context": [
-    "http://www.w3.org/ns/anno.jsonld",
-    "http://iiif.io/api/presentation/{{ page.major }}/context.json"
-  ],
-  "id": "https://example.org/iiif/book1/manifest",
-  "type": "Manifest" 
-}
-```
+{: .line-numbers data-download-link data-download-link-label="Download me" data-src="manifest.json" }
 
 # Related recipes
 
-Provide a bulleted list of related recipes and why they are relevant.
-
+* [Table of Contents - Opera](../0026-toc-opera/index.md) - Another example of using nested ranges to represent an opera's table of contents.
+* [Opera Multiple Canvases](../0065-opera-multiple-canvases/index.md) - The same opera from this example but in audio format split across multiple canvases.
 
 {% include acronyms.md %}
 {% include links.md %}

--- a/recipe/0064-opera-one-canvas/index.md
+++ b/recipe/0064-opera-one-canvas/index.md
@@ -13,7 +13,7 @@ Opera performances are generally long with lots of divisions, often hierarchical
 
 ## Implementation notes
 
-This implementation builds upon the [opera table of contents recipe](../0026-toc-opera/index.md) but adds metadata, homepage, and thumbnail properties for more more context.
+This implementation builds upon the [opera table of contents recipe](../0026-toc-opera/index.md) but uses two sound files, one for each act, annotated onto the same canvas.  It also includes metadata and thumbnail properties for more context.
 
 ## Restrictions
 

--- a/recipe/0064-opera-one-canvas/manifest.json
+++ b/recipe/0064-opera-one-canvas/manifest.json
@@ -1,10 +1,7 @@
 {
-  "@context": [
-    "http://www.w3.org/ns/anno.jsonld",
-    "http://iiif.io/api/presentation/3/context.json"
-  ],
+  "@context": "http://iiif.io/api/presentation/3/context.json",
   "type": "Manifest",
-  "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest",
+  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}",
   "label": {
     "it": [
       "L'elisir d'amore"
@@ -14,21 +11,6 @@
     ]
   },
   "metadata": [
-    {
-      "label": {
-        "en": [
-          "Title"
-        ]
-      },
-      "value": {
-        "it": [
-          "L'elisir d'amore"
-        ],
-        "en": [
-          "The elixir of love"
-        ]
-      }
-    },
     {
       "label": {
         "en": [
@@ -143,21 +125,21 @@
   ],
   "items": [
     {
-      "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/canvas/1",
+      "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1",
       "type": "Canvas",
       "width": 1920,
       "height": 1080,
       "duration": 7278.422,
       "items": [
         {
-          "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/canvas/1/annotation_page/1",
+          "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1/annotation_page/1",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/canvas/1/annotation_page/1/annotation/1",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1/annotation_page/1/annotation/1",
               "type": "Annotation",
               "motivation": "painting",
-              "target": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/canvas/1",
+              "target": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1",
               "body": {
                 "id": "https://iiif-av.s3.amazonaws.com/examples/indiana/donizetti-elixir/vae0637_accessH264_low.mp4",
                 "type": "Video",
@@ -175,7 +157,7 @@
   "structures": [
     {
       "type": "Range",
-      "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/range/r9ad47417-1344-4991-a41a-b084c69a12d4",
+      "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r9ad47417-1344-4991-a41a-b084c69a12d4",
       "label": {
         "en": [
           "IU Opera Theatre"
@@ -184,7 +166,7 @@
       "items": [
         {
           "type": "Range",
-          "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/range/r764d8a04-47a4-4aa5-bc68-a572ad33866a",
+          "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r764d8a04-47a4-4aa5-bc68-a572ad33866a",
           "label": {
             "en": [
               "[ambience]"
@@ -193,13 +175,13 @@
           "items": [
             {
               "type": "Canvas",
-              "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/canvas/1#t=0.0,26.17"
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=0.0,26.17"
             }
           ]
         },
         {
           "type": "Range",
-          "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/range/raa6a9c5b-79be-4d73-a3fc-2cb22e9e6618",
+          "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/raa6a9c5b-79be-4d73-a3fc-2cb22e9e6618",
           "label": {
             "it": [
               "Gaetano Donizetti, L'Elisir D'Amore"
@@ -208,7 +190,7 @@
           "items": [
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/range/r2ceb895e-a290-43b6-9351-f1fc8bad336c",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r2ceb895e-a290-43b6-9351-f1fc8bad336c",
               "label": {
                 "it": [
                   "Atto Primo – Preludio e Coro d'introduzione – Bel conforto al mietitore"
@@ -217,13 +199,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/canvas/1#t=26.17,302.05"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=26.17,302.05"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/range/r5061e574-e6c6-4e04-93ea-368f8afab78b",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r5061e574-e6c6-4e04-93ea-368f8afab78b",
               "label": {
                 "it": [
                   "Atto Primo – Cavatoma – Quanto é cara!"
@@ -232,13 +214,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/canvas/1#t=302.05,488.23"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=302.05,488.23"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/range/r2f07821a-33c0-49c3-8e28-2fa3bcdf1349",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r2f07821a-33c0-49c3-8e28-2fa3bcdf1349",
               "label": {
                 "it": [
                   "Atto Primo – Cavatina - Benedette queste carte! – Della crudele Isotta"
@@ -247,13 +229,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/canvas/1#t=488.23,770.29"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=488.23,770.29"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/range/rf2a0a534-4e5f-4280-a572-0f6b4d64246d",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/rf2a0a534-4e5f-4280-a572-0f6b4d64246d",
               "label": {
                 "it": [
                   "Atto Primo – Cavatina e Stretta d’introduzione – Come Paride vezzoso"
@@ -262,13 +244,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/canvas/1#t=770.29,1278.04"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=770.29,1278.04"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/range/r40dee6f3-6df4-42cc-b71c-7536d26df61e",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r40dee6f3-6df4-42cc-b71c-7536d26df61e",
               "label": {
                 "it": [
                   "Atto Primo – Recitativo – Intanto, o mia ragazza"
@@ -277,13 +259,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/canvas/1#t=1278.04,1314.05"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=1278.04,1314.05"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/range/rffadb10b-f45f-4f37-8566-cac50783f77c",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/rffadb10b-f45f-4f37-8566-cac50783f77c",
               "label": {
                 "it": [
                   "Atto Primo – Scene e Duetto – Una parola, o Adina – Chiedi all’aura lushinghiera"
@@ -292,13 +274,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/canvas/1#t=1314.05,1738.15"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=1314.05,1738.15"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/range/rf072516a-868d-4bf1-86b4-bba2951689ec",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/rf072516a-868d-4bf1-86b4-bba2951689ec",
               "label": {
                 "it": [
                   "Atto Primo – Coro – Che vuol dire codesta sonata?"
@@ -307,13 +289,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/canvas/1#t=1738.15,1855.24"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=1738.15,1855.24"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/range/r05fc5414-d4c9-416c-bb08-44aabde33a63",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r05fc5414-d4c9-416c-bb08-44aabde33a63",
               "label": {
                 "it": [
                   "Atto Primo – Cavatina – Udite, udite, o rustici"
@@ -322,13 +304,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/canvas/1#t=1855.24,2288.23"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=1855.24,2288.23"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/range/r60d2be49-2651-47da-9018-fb31758314ab",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r60d2be49-2651-47da-9018-fb31758314ab",
               "label": {
                 "it": [
                   "Atto Primo – Recitavio, Scena e Duetto – Ardir! – Voglio dire"
@@ -337,13 +319,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/canvas/1#t=2288.23,2705.21"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=2288.23,2705.21"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/range/r23b13c8a-27d1-416f-ba25-f71a7947a0b7",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r23b13c8a-27d1-416f-ba25-f71a7947a0b7",
               "label": {
                 "it": [
                   "Atto Primo – Recitavio – Caro Elisir! sei mio!"
@@ -352,13 +334,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/canvas/1#t=2705.21,2847.14"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=2705.21,2847.14"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/range/r04634ffa-bf37-4537-80e4-cf0d7919666a",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r04634ffa-bf37-4537-80e4-cf0d7919666a",
               "label": {
                 "it": [
                   "Atto Primo – Scene e Duetto – Lallarallarà, la, la – Esulti pur la Barbara"
@@ -367,13 +349,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/canvas/1#t=2847.14,3174.16"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=2847.14,3174.16"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/range/r95c31349-5bc1-4c4f-8fc1-7ff4e34133dc",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r95c31349-5bc1-4c4f-8fc1-7ff4e34133dc",
               "label": {
                 "it": [
                   "Atto Primo – Terzetto – In Guerra ed in amore"
@@ -382,13 +364,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/canvas/1#t=3174.16,3370.2"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=3174.16,3370.2"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/range/re9d2963f-ed54-4ff8-9f0f-19e2be05bf0e",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/re9d2963f-ed54-4ff8-9f0f-19e2be05bf0e",
               "label": {
                 "it": [
                   "Atto Primo – Quartetto e Stretta del Finale I – Signor sergente – Adina, credimi"
@@ -397,7 +379,7 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/canvas/1#t=3370.2,3971.24"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=3370.2,3971.24"
                 }
               ]
             }
@@ -405,7 +387,7 @@
         },
         {
           "type": "Range",
-          "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/range/r3e7e0b40-026d-43d0-8281-9e0dc11ae674",
+          "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r3e7e0b40-026d-43d0-8281-9e0dc11ae674",
           "label": {
             "en": [
               "[ambience]"
@@ -414,13 +396,13 @@
           "items": [
             {
               "type": "Canvas",
-              "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/canvas/1#t=3971.24,4004.13"
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=3971.24,4004.13"
             }
           ]
         },
         {
           "type": "Range",
-          "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/range/rf7350bab-17b7-4b7d-858e-e8c83e8cef7a",
+          "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/rf7350bab-17b7-4b7d-858e-e8c83e8cef7a",
           "label": {
             "it": [
               "Gaetano Donizetti, L'Elisir D'Amore"
@@ -429,7 +411,7 @@
           "items": [
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/range/rdedd2c01-86be-4f7b-bfcc-586848bb0cd0",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/rdedd2c01-86be-4f7b-bfcc-586848bb0cd0",
               "label": {
                 "it": [
                   "Atto Secondo – Coro d’Introduzione – Cantiamo, facciam brindisi"
@@ -438,13 +420,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/canvas/1#t=4004.13,4140.28"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=4004.13,4140.28"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/range/r00d145d8-7bd7-4077-be4c-247cc026c811",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r00d145d8-7bd7-4077-be4c-247cc026c811",
               "label": {
                 "it": [
                   "Atto Secondo – Recitativo – Poiché cantar vi alletta"
@@ -453,13 +435,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/canvas/1#t=4140.28,4188.16"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=4140.28,4188.16"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/range/r1c7aa4ff-9200-475c-9df5-61618c0fec35",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r1c7aa4ff-9200-475c-9df5-61618c0fec35",
               "label": {
                 "it": [
                   "Atto Secondo – Barcarola a due voci – Io son ricco e tu sei bella"
@@ -468,13 +450,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/canvas/1#t=4188.16,4331.02"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=4188.16,4331.02"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/range/rc31de5e6-0db6-4893-8383-af6fbf429f7a",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/rc31de5e6-0db6-4893-8383-af6fbf429f7a",
               "label": {
                 "it": [
                   "Atto Secondo – Recotativo – Silenzio! È qua il notaro"
@@ -483,13 +465,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/canvas/1#t=4331.02,4533.0"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=4331.02,4533.0"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/range/r97bfe0c8-0fed-4c8a-9412-fefec5c891fc",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r97bfe0c8-0fed-4c8a-9412-fefec5c891fc",
               "label": {
                 "it": [
                   "Atto Secondo – Scena e Duetto – La donna è en animale stravagante – Venti scudi"
@@ -498,13 +480,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/canvas/1#t=4533.0,5019.12"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=4533.0,5019.12"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/range/r8e68d5c5-6931-4532-ac1b-212f437ce89b",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r8e68d5c5-6931-4532-ac1b-212f437ce89b",
               "label": {
                 "it": [
                   "Atto Secondo – Coro – Saria possibil?"
@@ -513,13 +495,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/canvas/1#t=5019.12,5254.26"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=5019.12,5254.26"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/range/re14797a3-4222-4922-814a-a4fa12f989ea",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/re14797a3-4222-4922-814a-a4fa12f989ea",
               "label": {
                 "it": [
                   "Atto Secondo – Quartetto – Dell’elisir mirabile"
@@ -528,13 +510,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/canvas/1#t=5254.26,5658.139999999999"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=5254.26,5658.139999999999"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/range/re0591627-b002-4dec-a579-cc01b12b30d4",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/re0591627-b002-4dec-a579-cc01b12b30d4",
               "label": {
                 "it": [
                   "Atto Secondo – Recitativo e Duetto – Come sen va contento! – Quanto amore!"
@@ -543,13 +525,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/canvas/1#t=5658.139999999999,6133.25"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=5658.139999999999,6133.25"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/range/ra6cec2bb-4028-4f34-bcf5-3406d5252853",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/ra6cec2bb-4028-4f34-bcf5-3406d5252853",
               "label": {
                 "it": [
                   "Atto Secondo – Romanza – Una furtiva lagrima"
@@ -558,13 +540,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/canvas/1#t=6133.25,6412.27"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=6133.25,6412.27"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/range/r7ec19a5a-e1cc-4db1-ab96-0ad578b90cc9",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r7ec19a5a-e1cc-4db1-ab96-0ad578b90cc9",
               "label": {
                 "it": [
                   "Atto Secondo – Recitativo ed Aria - Eccola – Prendi, Per me sei Libero"
@@ -573,13 +555,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/canvas/1#t=6412.27,6941.01"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=6412.27,6941.01"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/range/r2b320d47-3996-4901-9322-808583958672",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r2b320d47-3996-4901-9322-808583958672",
               "label": {
                 "it": [
                   "Atto Secondo – Recitativo – Aria e Finale II - Alto! – Fronte! – Eli corregge ogni difetto"
@@ -588,7 +570,7 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/canvas/1#t=6941.01,7278.0"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=6941.01,7278.0"
                 }
               ]
             }

--- a/recipe/0064-opera-one-canvas/manifest.json
+++ b/recipe/0064-opera-one-canvas/manifest.json
@@ -2,27 +2,8 @@
   "@context": "http://iiif.io/api/presentation/3/context.json",
   "type": "Manifest",
   "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}",
-  "label": {
-    "it": [
-      "L'elisir d'amore"
-    ],
-    "en": [
-      "The elixir of love"
-    ]
-  },
+  "label": { "it": [ "L'elisir d'amore" ], "en": [ "The elixir of love" ] },
   "metadata": [
-    {
-      "label": {
-        "en": [
-          "Creator"
-        ]
-      },
-      "value": {
-        "en": [
-          "See Other Contributors"
-        ]
-      }
-    },
     {
       "label": {
         "en": [
@@ -71,56 +52,6 @@
           "Indiana University Jacobs School of Music"
         ]
       }
-    },
-    {
-      "label": {
-        "en": [
-          "Subject"
-        ]
-      },
-      "value": {
-        "en": [
-          "Operas"
-        ]
-      }
-    },
-    {
-      "label": {
-        "en": [
-          "Genre"
-        ]
-      },
-      "value": {
-        "en": [
-          "Operas.",
-          "Filmed performances.",
-          "Live sound recordings."
-        ]
-      }
-    },
-    {
-      "label": {
-        "en": [
-          "Topical Subject"
-        ]
-      },
-      "value": {
-        "en": [
-          "Operas"
-        ]
-      }
-    }
-  ],
-  "homepage": [
-    {
-      "id": "https://purl.dlib.indiana.edu/iudl/media/q085549g74",
-      "type": "Text",
-      "label": {
-        "en": [
-          "View in Repository"
-        ]
-      },
-      "format": "text/html"
     }
   ],
   "items": [
@@ -141,15 +72,41 @@
               "motivation": "painting",
               "target": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1",
               "body": {
-                "id": "https://iiif-av.s3.amazonaws.com/examples/indiana/donizetti-elixir/vae0637_accessH264_low.mp4",
+                "id": "https://fixtures.iiif.io/video/indiana/donizetti-elixir/vae0637_accessH264_low.mp4",
                 "type": "Video",
                 "format": "video/mp4",
                 "height": 1080,
                 "width": 1920,
-                "duration": 7278.422
+                "duration": 3971.24
               }
             }
           ]
+        },
+        {
+          "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1/annotation_page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1/annotation_page/1/annotation/2",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1",
+              "body": {
+                "id": "https://fixtures.iiif.io/video/indiana/donizetti-elixir/vae0637_accessH264_low_act_2.mp4",
+                "type": "Video",
+                "format": "video/mp4",
+                "height": 1080,
+                "width": 1920,
+                "duration": 3307.22
+              }
+            }
+          ]
+        }
+      ],
+      "thumbnail": [
+        {
+          "id": "https://media.dlib.indiana.edu/master_files/vt150p78b/thumbnail",
+          "type": "Image"
         }
       ]
     }
@@ -166,25 +123,10 @@
       "items": [
         {
           "type": "Range",
-          "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r764d8a04-47a4-4aa5-bc68-a572ad33866a",
-          "label": {
-            "en": [
-              "[ambience]"
-            ]
-          },
-          "items": [
-            {
-              "type": "Canvas",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=0.0,26.17"
-            }
-          ]
-        },
-        {
-          "type": "Range",
           "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/raa6a9c5b-79be-4d73-a3fc-2cb22e9e6618",
           "label": {
             "it": [
-              "Gaetano Donizetti, L'Elisir D'Amore"
+              "Gaetano Donizetti, L'Elisir D'Amore, Atto Primo"
             ]
           },
           "items": [
@@ -193,13 +135,13 @@
               "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r2ceb895e-a290-43b6-9351-f1fc8bad336c",
               "label": {
                 "it": [
-                  "Atto Primo – Preludio e Coro d'introduzione – Bel conforto al mietitore"
+                  "Preludio e Coro d'introduzione – Bel conforto al mietitore"
                 ]
               },
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=26.17,302.05"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=0,302.05"
                 }
               ]
             },
@@ -207,196 +149,16 @@
               "type": "Range",
               "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r5061e574-e6c6-4e04-93ea-368f8afab78b",
               "label": {
-                "it": [
-                  "Atto Primo – Cavatoma – Quanto é cara!"
+                "en": [
+                  "Remainder of Act I"
                 ]
               },
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=302.05,488.23"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=302.05,3971.24"
                 }
               ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r2f07821a-33c0-49c3-8e28-2fa3bcdf1349",
-              "label": {
-                "it": [
-                  "Atto Primo – Cavatina - Benedette queste carte! – Della crudele Isotta"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=488.23,770.29"
-                }
-              ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/rf2a0a534-4e5f-4280-a572-0f6b4d64246d",
-              "label": {
-                "it": [
-                  "Atto Primo – Cavatina e Stretta d’introduzione – Come Paride vezzoso"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=770.29,1278.04"
-                }
-              ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r40dee6f3-6df4-42cc-b71c-7536d26df61e",
-              "label": {
-                "it": [
-                  "Atto Primo – Recitativo – Intanto, o mia ragazza"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=1278.04,1314.05"
-                }
-              ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/rffadb10b-f45f-4f37-8566-cac50783f77c",
-              "label": {
-                "it": [
-                  "Atto Primo – Scene e Duetto – Una parola, o Adina – Chiedi all’aura lushinghiera"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=1314.05,1738.15"
-                }
-              ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/rf072516a-868d-4bf1-86b4-bba2951689ec",
-              "label": {
-                "it": [
-                  "Atto Primo – Coro – Che vuol dire codesta sonata?"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=1738.15,1855.24"
-                }
-              ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r05fc5414-d4c9-416c-bb08-44aabde33a63",
-              "label": {
-                "it": [
-                  "Atto Primo – Cavatina – Udite, udite, o rustici"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=1855.24,2288.23"
-                }
-              ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r60d2be49-2651-47da-9018-fb31758314ab",
-              "label": {
-                "it": [
-                  "Atto Primo – Recitavio, Scena e Duetto – Ardir! – Voglio dire"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=2288.23,2705.21"
-                }
-              ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r23b13c8a-27d1-416f-ba25-f71a7947a0b7",
-              "label": {
-                "it": [
-                  "Atto Primo – Recitavio – Caro Elisir! sei mio!"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=2705.21,2847.14"
-                }
-              ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r04634ffa-bf37-4537-80e4-cf0d7919666a",
-              "label": {
-                "it": [
-                  "Atto Primo – Scene e Duetto – Lallarallarà, la, la – Esulti pur la Barbara"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=2847.14,3174.16"
-                }
-              ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r95c31349-5bc1-4c4f-8fc1-7ff4e34133dc",
-              "label": {
-                "it": [
-                  "Atto Primo – Terzetto – In Guerra ed in amore"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=3174.16,3370.2"
-                }
-              ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/re9d2963f-ed54-4ff8-9f0f-19e2be05bf0e",
-              "label": {
-                "it": [
-                  "Atto Primo – Quartetto e Stretta del Finale I – Signor sergente – Adina, credimi"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=3370.2,3971.24"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "Range",
-          "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r3e7e0b40-026d-43d0-8281-9e0dc11ae674",
-          "label": {
-            "en": [
-              "[ambience]"
-            ]
-          },
-          "items": [
-            {
-              "type": "Canvas",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=3971.24,4004.13"
             }
           ]
         },
@@ -405,184 +167,17 @@
           "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/rf7350bab-17b7-4b7d-858e-e8c83e8cef7a",
           "label": {
             "it": [
-              "Gaetano Donizetti, L'Elisir D'Amore"
+              "Gaetano Donizetti, L'Elisir D'Amore, Atto Secondo"
             ]
           },
           "items": [
             {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/rdedd2c01-86be-4f7b-bfcc-586848bb0cd0",
-              "label": {
-                "it": [
-                  "Atto Secondo – Coro d’Introduzione – Cantiamo, facciam brindisi"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=4004.13,4140.28"
-                }
-              ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r00d145d8-7bd7-4077-be4c-247cc026c811",
-              "label": {
-                "it": [
-                  "Atto Secondo – Recitativo – Poiché cantar vi alletta"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=4140.28,4188.16"
-                }
-              ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r1c7aa4ff-9200-475c-9df5-61618c0fec35",
-              "label": {
-                "it": [
-                  "Atto Secondo – Barcarola a due voci – Io son ricco e tu sei bella"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=4188.16,4331.02"
-                }
-              ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/rc31de5e6-0db6-4893-8383-af6fbf429f7a",
-              "label": {
-                "it": [
-                  "Atto Secondo – Recotativo – Silenzio! È qua il notaro"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=4331.02,4533.0"
-                }
-              ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r97bfe0c8-0fed-4c8a-9412-fefec5c891fc",
-              "label": {
-                "it": [
-                  "Atto Secondo – Scena e Duetto – La donna è en animale stravagante – Venti scudi"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=4533.0,5019.12"
-                }
-              ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r8e68d5c5-6931-4532-ac1b-212f437ce89b",
-              "label": {
-                "it": [
-                  "Atto Secondo – Coro – Saria possibil?"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=5019.12,5254.26"
-                }
-              ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/re14797a3-4222-4922-814a-a4fa12f989ea",
-              "label": {
-                "it": [
-                  "Atto Secondo – Quartetto – Dell’elisir mirabile"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=5254.26,5658.139999999999"
-                }
-              ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/re0591627-b002-4dec-a579-cc01b12b30d4",
-              "label": {
-                "it": [
-                  "Atto Secondo – Recitativo e Duetto – Come sen va contento! – Quanto amore!"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=5658.139999999999,6133.25"
-                }
-              ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/ra6cec2bb-4028-4f34-bcf5-3406d5252853",
-              "label": {
-                "it": [
-                  "Atto Secondo – Romanza – Una furtiva lagrima"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=6133.25,6412.27"
-                }
-              ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r7ec19a5a-e1cc-4db1-ab96-0ad578b90cc9",
-              "label": {
-                "it": [
-                  "Atto Secondo – Recitativo ed Aria - Eccola – Prendi, Per me sei Libero"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=6412.27,6941.01"
-                }
-              ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r2b320d47-3996-4901-9322-808583958672",
-              "label": {
-                "it": [
-                  "Atto Secondo – Recitativo – Aria e Finale II - Alto! – Fronte! – Eli corregge ogni difetto"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=6941.01,7278.0"
-                }
-              ]
+              "type": "Canvas",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=3971.24,7278.422"
             }
           ]
         }
       ]
-    }
-  ],
-  "thumbnail": [
-    {
-      "id": "https://media.dlib.indiana.edu/master_files/vt150p78b/thumbnail",
-      "type": "Image"
     }
   ]
 }

--- a/recipe/0064-opera-one-canvas/manifest.json
+++ b/recipe/0064-opera-one-canvas/manifest.json
@@ -1,0 +1,606 @@
+{
+  "@context": [
+    "http://www.w3.org/ns/anno.jsonld",
+    "http://iiif.io/api/presentation/3/context.json"
+  ],
+  "type": "Manifest",
+  "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest",
+  "label": {
+    "it": [
+      "L'elisir d'amore"
+    ],
+    "en": [
+      "The elixir of love"
+    ]
+  },
+  "metadata": [
+    {
+      "label": {
+        "en": [
+          "Title"
+        ]
+      },
+      "value": {
+        "it": [
+          "L'elisir d'amore"
+        ],
+        "en": [
+          "The elixir of love"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Creator"
+        ]
+      },
+      "value": {
+        "en": [
+          "See Other Contributors"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Date Issued"
+        ]
+      },
+      "value": {
+        "en": [
+          "2019"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Contributor"
+        ]
+      },
+      "value": {
+        "en": [
+          "Romani, Felice, 1788-1865",
+          "Neely, David",
+          "Boyd, Spencer (Spencer Lawrence)",
+          "Boettcher, Avery",
+          "Sandes, Bruno",
+          "Ceballos de la Mora, Ricardo",
+          "Webber, Savanna",
+          "Porter, John Christopher",
+          "Brovsky, Linda",
+          "O'Hearn, Robert",
+          "Tzvetkov, Dana",
+          "Hase, Thomas C.",
+          "Siena, Daniela",
+          "Indiana University Opera Theater"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Publisher"
+        ]
+      },
+      "value": {
+        "en": [
+          "Indiana University Jacobs School of Music"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Subject"
+        ]
+      },
+      "value": {
+        "en": [
+          "Operas"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Genre"
+        ]
+      },
+      "value": {
+        "en": [
+          "Operas.",
+          "Filmed performances.",
+          "Live sound recordings."
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Topical Subject"
+        ]
+      },
+      "value": {
+        "en": [
+          "Operas"
+        ]
+      }
+    }
+  ],
+  "homepage": [
+    {
+      "id": "https://purl.dlib.indiana.edu/iudl/media/q085549g74",
+      "type": "Text",
+      "label": {
+        "en": [
+          "View in Repository"
+        ]
+      },
+      "format": "text/html"
+    }
+  ],
+  "items": [
+    {
+      "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/canvas/1",
+      "type": "Canvas",
+      "width": 1920,
+      "height": 1080,
+      "duration": 7278.422,
+      "items": [
+        {
+          "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/canvas/1/annotation_page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/canvas/1/annotation_page/1/annotation/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/canvas/1",
+              "body": {
+                "id": "https://iiif-av.s3.amazonaws.com/examples/indiana/donizetti-elixir/vae0637_accessH264_low.mp4",
+                "type": "Video",
+                "format": "video/mp4",
+                "height": 1080,
+                "width": 1920,
+                "duration": 7278.422
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "structures": [
+    {
+      "type": "Range",
+      "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/range/r9ad47417-1344-4991-a41a-b084c69a12d4",
+      "label": {
+        "en": [
+          "IU Opera Theatre"
+        ]
+      },
+      "items": [
+        {
+          "type": "Range",
+          "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/range/r764d8a04-47a4-4aa5-bc68-a572ad33866a",
+          "label": {
+            "en": [
+              "[ambience]"
+            ]
+          },
+          "items": [
+            {
+              "type": "Canvas",
+              "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/canvas/1#t=0.0,26.17"
+            }
+          ]
+        },
+        {
+          "type": "Range",
+          "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/range/raa6a9c5b-79be-4d73-a3fc-2cb22e9e6618",
+          "label": {
+            "it": [
+              "Gaetano Donizetti, L'Elisir D'Amore"
+            ]
+          },
+          "items": [
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/range/r2ceb895e-a290-43b6-9351-f1fc8bad336c",
+              "label": {
+                "it": [
+                  "Atto Primo – Preludio e Coro d'introduzione – Bel conforto al mietitore"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/canvas/1#t=26.17,302.05"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/range/r5061e574-e6c6-4e04-93ea-368f8afab78b",
+              "label": {
+                "it": [
+                  "Atto Primo – Cavatoma – Quanto é cara!"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/canvas/1#t=302.05,488.23"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/range/r2f07821a-33c0-49c3-8e28-2fa3bcdf1349",
+              "label": {
+                "it": [
+                  "Atto Primo – Cavatina - Benedette queste carte! – Della crudele Isotta"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/canvas/1#t=488.23,770.29"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/range/rf2a0a534-4e5f-4280-a572-0f6b4d64246d",
+              "label": {
+                "it": [
+                  "Atto Primo – Cavatina e Stretta d’introduzione – Come Paride vezzoso"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/canvas/1#t=770.29,1278.04"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/range/r40dee6f3-6df4-42cc-b71c-7536d26df61e",
+              "label": {
+                "it": [
+                  "Atto Primo – Recitativo – Intanto, o mia ragazza"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/canvas/1#t=1278.04,1314.05"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/range/rffadb10b-f45f-4f37-8566-cac50783f77c",
+              "label": {
+                "it": [
+                  "Atto Primo – Scene e Duetto – Una parola, o Adina – Chiedi all’aura lushinghiera"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/canvas/1#t=1314.05,1738.15"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/range/rf072516a-868d-4bf1-86b4-bba2951689ec",
+              "label": {
+                "it": [
+                  "Atto Primo – Coro – Che vuol dire codesta sonata?"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/canvas/1#t=1738.15,1855.24"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/range/r05fc5414-d4c9-416c-bb08-44aabde33a63",
+              "label": {
+                "it": [
+                  "Atto Primo – Cavatina – Udite, udite, o rustici"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/canvas/1#t=1855.24,2288.23"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/range/r60d2be49-2651-47da-9018-fb31758314ab",
+              "label": {
+                "it": [
+                  "Atto Primo – Recitavio, Scena e Duetto – Ardir! – Voglio dire"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/canvas/1#t=2288.23,2705.21"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/range/r23b13c8a-27d1-416f-ba25-f71a7947a0b7",
+              "label": {
+                "it": [
+                  "Atto Primo – Recitavio – Caro Elisir! sei mio!"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/canvas/1#t=2705.21,2847.14"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/range/r04634ffa-bf37-4537-80e4-cf0d7919666a",
+              "label": {
+                "it": [
+                  "Atto Primo – Scene e Duetto – Lallarallarà, la, la – Esulti pur la Barbara"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/canvas/1#t=2847.14,3174.16"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/range/r95c31349-5bc1-4c4f-8fc1-7ff4e34133dc",
+              "label": {
+                "it": [
+                  "Atto Primo – Terzetto – In Guerra ed in amore"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/canvas/1#t=3174.16,3370.2"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/range/re9d2963f-ed54-4ff8-9f0f-19e2be05bf0e",
+              "label": {
+                "it": [
+                  "Atto Primo – Quartetto e Stretta del Finale I – Signor sergente – Adina, credimi"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/canvas/1#t=3370.2,3971.24"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Range",
+          "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/range/r3e7e0b40-026d-43d0-8281-9e0dc11ae674",
+          "label": {
+            "en": [
+              "[ambience]"
+            ]
+          },
+          "items": [
+            {
+              "type": "Canvas",
+              "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/canvas/1#t=3971.24,4004.13"
+            }
+          ]
+        },
+        {
+          "type": "Range",
+          "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/range/rf7350bab-17b7-4b7d-858e-e8c83e8cef7a",
+          "label": {
+            "it": [
+              "Gaetano Donizetti, L'Elisir D'Amore"
+            ]
+          },
+          "items": [
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/range/rdedd2c01-86be-4f7b-bfcc-586848bb0cd0",
+              "label": {
+                "it": [
+                  "Atto Secondo – Coro d’Introduzione – Cantiamo, facciam brindisi"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/canvas/1#t=4004.13,4140.28"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/range/r00d145d8-7bd7-4077-be4c-247cc026c811",
+              "label": {
+                "it": [
+                  "Atto Secondo – Recitativo – Poiché cantar vi alletta"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/canvas/1#t=4140.28,4188.16"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/range/r1c7aa4ff-9200-475c-9df5-61618c0fec35",
+              "label": {
+                "it": [
+                  "Atto Secondo – Barcarola a due voci – Io son ricco e tu sei bella"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/canvas/1#t=4188.16,4331.02"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/range/rc31de5e6-0db6-4893-8383-af6fbf429f7a",
+              "label": {
+                "it": [
+                  "Atto Secondo – Recotativo – Silenzio! È qua il notaro"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/canvas/1#t=4331.02,4533.0"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/range/r97bfe0c8-0fed-4c8a-9412-fefec5c891fc",
+              "label": {
+                "it": [
+                  "Atto Secondo – Scena e Duetto – La donna è en animale stravagante – Venti scudi"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/canvas/1#t=4533.0,5019.12"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/range/r8e68d5c5-6931-4532-ac1b-212f437ce89b",
+              "label": {
+                "it": [
+                  "Atto Secondo – Coro – Saria possibil?"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/canvas/1#t=5019.12,5254.26"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/range/re14797a3-4222-4922-814a-a4fa12f989ea",
+              "label": {
+                "it": [
+                  "Atto Secondo – Quartetto – Dell’elisir mirabile"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/canvas/1#t=5254.26,5658.139999999999"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/range/re0591627-b002-4dec-a579-cc01b12b30d4",
+              "label": {
+                "it": [
+                  "Atto Secondo – Recitativo e Duetto – Come sen va contento! – Quanto amore!"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/canvas/1#t=5658.139999999999,6133.25"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/range/ra6cec2bb-4028-4f34-bcf5-3406d5252853",
+              "label": {
+                "it": [
+                  "Atto Secondo – Romanza – Una furtiva lagrima"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/canvas/1#t=6133.25,6412.27"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/range/r7ec19a5a-e1cc-4db1-ab96-0ad578b90cc9",
+              "label": {
+                "it": [
+                  "Atto Secondo – Recitativo ed Aria - Eccola – Prendi, Per me sei Libero"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/canvas/1#t=6412.27,6941.01"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/range/r2b320d47-3996-4901-9322-808583958672",
+              "label": {
+                "it": [
+                  "Atto Secondo – Recitativo – Aria e Finale II - Alto! – Fronte! – Eli corregge ogni difetto"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0064-opera-one-canvas/manifest/canvas/1#t=6941.01,7278.0"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "thumbnail": [
+    {
+      "id": "https://media.dlib.indiana.edu/master_files/vt150p78b/thumbnail",
+      "type": "Image"
+    }
+  ]
+}

--- a/recipe/0065-opera-multiple-canvases/index.md
+++ b/recipe/0065-opera-multiple-canvases/index.md
@@ -2,43 +2,31 @@
 title: An opera on multiple Canvases
 id: 65
 layout: recipe
-tags: [tbc]
-summary: "tbc"
+tags: [video, presentation, opera]
+summary: "A real world example of an audio recording of an opera spread across multiple canvases."
 ---
 
 
 ## Use Case
 
-Why is this pattern is important?
+An opera performance can be long and split across multiple physical tapes, reels, or cassettes.  These may be digitized as one file per physical medium then mapped to one canvas per file.  This real world example shows how this can be modeled using multiple canvases.
 
 ## Implementation notes
 
-How does one implement the pattern?
+Implementation is identical to the [opera on one canvas recipe](../0064-opera-one-canvas/index.md) except that there are two files, one for each act.  These files each have their own canvas and are referenced as such in the structures.
 
 ## Restrictions
 
-When is this pattern is usable / not usable? Is it deprecated? If it uses multiple specifications, which versions are needed, etc.? (Not present if not needed.)
+None known.
 
 ## Example
 
-Describe in prose and provide examples, e.g.: 
-
-``` json-doc
-{
-  "@context": [
-    "http://www.w3.org/ns/anno.jsonld",
-    "http://iiif.io/api/presentation/{{ page.major }}/context.json"
-  ],
-  "id": "https://example.org/iiif/book1/manifest",
-  "type": "Manifest" 
-}
-```
+{: .line-numbers data-download-link data-download-link-label="Download me" data-src="manifest.json" }
 
 # Related recipes
 
-Provide a bulleted list of related recipes and why they are relevant.
-
+* [Table of Contents - Opera](../0026-toc-opera/index.md) - Another example of using nested ranges to represent an opera's table of contents.
+* [Opera One Canvas](../0064-opera-one-canvas/index.md) - The same opera from this example but in video format on one canvas.
 
 {% include acronyms.md %}
 {% include links.md %}
-

--- a/recipe/0065-opera-multiple-canvases/index.md
+++ b/recipe/0065-opera-multiple-canvases/index.md
@@ -13,7 +13,7 @@ An opera performance can be long and split across multiple physical tapes, reels
 
 ## Implementation notes
 
-Implementation is identical to the [opera on one canvas recipe](../0064-opera-one-canvas/index.md) except that there are two files, one for each act.  These files each have their own canvas and are referenced as such in the structures.
+Implementation is identical to the [opera on one canvas recipe](../0064-opera-one-canvas/index.md) except that the two files, one for each act, each have their own canvas and are referenced as such in the structures.
 
 ## Restrictions
 

--- a/recipe/0065-opera-multiple-canvases/manifest.json
+++ b/recipe/0065-opera-multiple-canvases/manifest.json
@@ -1,10 +1,7 @@
 {
-  "@context": [
-    "http://www.w3.org/ns/anno.jsonld",
-    "http://iiif.io/api/presentation/3/context.json"
-  ],
+  "@context": "http://iiif.io/api/presentation/3/context.json",
   "type": "Manifest",
-  "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest",
+  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}",
   "label": {
     "it": [
       "L'elisir d'amore"
@@ -14,21 +11,6 @@
     ]
   },
   "metadata": [
-    {
-      "label": {
-        "en": [
-          "Title"
-        ]
-      },
-      "value": {
-        "it": [
-          "L'elisir d'amore"
-        ],
-        "en": [
-          "The elixir of love"
-        ]
-      }
-    },
     {
       "label": {
         "en": [
@@ -143,7 +125,7 @@
   ],
   "items": [
     {
-      "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/1",
+      "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1",
       "type": "Canvas",
       "width": 1920,
       "height": 1080,
@@ -151,14 +133,14 @@
       "label": { "en": [ "Act I" ] },
       "items": [
         {
-          "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/1/annotation_page/1",
+          "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1/annotation_page/1",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/1/annotation_page/1/annotation/1",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1/annotation_page/1/annotation/1",
               "type": "Annotation",
               "motivation": "painting",
-              "target": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/1",
+              "target": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1",
               "body": {
                 "id": "https://iiif-av.s3.amazonaws.com/examples/indiana/donizetti-elixir/vae0637_accessH264_low_act_1.mp4",
                 "type": "Video",
@@ -173,7 +155,7 @@
       ]
     },
     {
-      "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/2",
+      "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/2",
       "type": "Canvas",
       "width": 1920,
       "height": 1080,
@@ -181,14 +163,14 @@
       "label": { "en": [ "Act II" ] },
       "items": [
         {
-          "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/2/annotation_page/1",
+          "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/2/annotation_page/1",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/2/annotation_page/1/annotation/1",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/2/annotation_page/1/annotation/1",
               "type": "Annotation",
               "motivation": "painting",
-              "target": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/2",
+              "target": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/2",
               "body": {
                 "id": "https://iiif-av.s3.amazonaws.com/examples/indiana/donizetti-elixir/vae0637_accessH264_low_act_2.mp4",
                 "type": "Video",
@@ -206,7 +188,7 @@
   "structures": [
     {
       "type": "Range",
-      "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/range/r9ad47417-1344-4991-a41a-b084c69a12d4",
+      "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r9ad47417-1344-4991-a41a-b084c69a12d4",
       "label": {
         "en": [
           "IU Opera Theatre"
@@ -215,7 +197,7 @@
       "items": [
         {
           "type": "Range",
-          "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/range/r764d8a04-47a4-4aa5-bc68-a572ad33866a",
+          "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r764d8a04-47a4-4aa5-bc68-a572ad33866a",
           "label": {
             "en": [
               "[ambience]"
@@ -224,13 +206,13 @@
           "items": [
             {
               "type": "Canvas",
-              "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/1#t=0.0,26.17"
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=0.0,26.17"
             }
           ]
         },
         {
           "type": "Range",
-          "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/range/raa6a9c5b-79be-4d73-a3fc-2cb22e9e6618",
+          "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/raa6a9c5b-79be-4d73-a3fc-2cb22e9e6618",
           "label": {
             "it": [
               "Gaetano Donizetti, L'Elisir D'Amore"
@@ -239,7 +221,7 @@
           "items": [
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/range/r2ceb895e-a290-43b6-9351-f1fc8bad336c",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r2ceb895e-a290-43b6-9351-f1fc8bad336c",
               "label": {
                 "it": [
                   "Atto Primo – Preludio e Coro d'introduzione – Bel conforto al mietitore"
@@ -248,13 +230,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/1#t=26.17,302.05"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=26.17,302.05"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/range/r5061e574-e6c6-4e04-93ea-368f8afab78b",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r5061e574-e6c6-4e04-93ea-368f8afab78b",
               "label": {
                 "it": [
                   "Atto Primo – Cavatoma – Quanto é cara!"
@@ -263,13 +245,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/1#t=302.05,488.23"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=302.05,488.23"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/range/r2f07821a-33c0-49c3-8e28-2fa3bcdf1349",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r2f07821a-33c0-49c3-8e28-2fa3bcdf1349",
               "label": {
                 "it": [
                   "Atto Primo – Cavatina - Benedette queste carte! – Della crudele Isotta"
@@ -278,13 +260,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/1#t=488.23,770.29"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=488.23,770.29"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/range/rf2a0a534-4e5f-4280-a572-0f6b4d64246d",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/rf2a0a534-4e5f-4280-a572-0f6b4d64246d",
               "label": {
                 "it": [
                   "Atto Primo – Cavatina e Stretta d’introduzione – Come Paride vezzoso"
@@ -293,13 +275,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/1#t=770.29,1278.04"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=770.29,1278.04"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/range/r40dee6f3-6df4-42cc-b71c-7536d26df61e",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r40dee6f3-6df4-42cc-b71c-7536d26df61e",
               "label": {
                 "it": [
                   "Atto Primo – Recitativo – Intanto, o mia ragazza"
@@ -308,13 +290,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/1#t=1278.04,1314.05"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=1278.04,1314.05"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/range/rffadb10b-f45f-4f37-8566-cac50783f77c",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/rffadb10b-f45f-4f37-8566-cac50783f77c",
               "label": {
                 "it": [
                   "Atto Primo – Scene e Duetto – Una parola, o Adina – Chiedi all’aura lushinghiera"
@@ -323,13 +305,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/1#t=1314.05,1738.15"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=1314.05,1738.15"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/range/rf072516a-868d-4bf1-86b4-bba2951689ec",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/rf072516a-868d-4bf1-86b4-bba2951689ec",
               "label": {
                 "it": [
                   "Atto Primo – Coro – Che vuol dire codesta sonata?"
@@ -338,13 +320,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/1#t=1738.15,1855.24"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=1738.15,1855.24"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/range/r05fc5414-d4c9-416c-bb08-44aabde33a63",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r05fc5414-d4c9-416c-bb08-44aabde33a63",
               "label": {
                 "it": [
                   "Atto Primo – Cavatina – Udite, udite, o rustici"
@@ -353,13 +335,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/1#t=1855.24,2288.23"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=1855.24,2288.23"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/range/r60d2be49-2651-47da-9018-fb31758314ab",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r60d2be49-2651-47da-9018-fb31758314ab",
               "label": {
                 "it": [
                   "Atto Primo – Recitavio, Scena e Duetto – Ardir! – Voglio dire"
@@ -368,13 +350,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/1#t=2288.23,2705.21"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=2288.23,2705.21"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/range/r23b13c8a-27d1-416f-ba25-f71a7947a0b7",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r23b13c8a-27d1-416f-ba25-f71a7947a0b7",
               "label": {
                 "it": [
                   "Atto Primo – Recitavio – Caro Elisir! sei mio!"
@@ -383,13 +365,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/1#t=2705.21,2847.14"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=2705.21,2847.14"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/range/r04634ffa-bf37-4537-80e4-cf0d7919666a",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r04634ffa-bf37-4537-80e4-cf0d7919666a",
               "label": {
                 "it": [
                   "Atto Primo – Scene e Duetto – Lallarallarà, la, la – Esulti pur la Barbara"
@@ -398,13 +380,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/1#t=2847.14,3174.16"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=2847.14,3174.16"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/range/r95c31349-5bc1-4c4f-8fc1-7ff4e34133dc",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r95c31349-5bc1-4c4f-8fc1-7ff4e34133dc",
               "label": {
                 "it": [
                   "Atto Primo – Terzetto – In Guerra ed in amore"
@@ -413,13 +395,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/1#t=3174.16,3370.2"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=3174.16,3370.2"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/range/re9d2963f-ed54-4ff8-9f0f-19e2be05bf0e",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/re9d2963f-ed54-4ff8-9f0f-19e2be05bf0e",
               "label": {
                 "it": [
                   "Atto Primo – Quartetto e Stretta del Finale I – Signor sergente – Adina, credimi"
@@ -428,7 +410,7 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/1#t=3370.2,3971.24"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=3370.2,3971.24"
                 }
               ]
             }
@@ -436,7 +418,7 @@
         },
         {
           "type": "Range",
-          "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/range/r3e7e0b40-026d-43d0-8281-9e0dc11ae674",
+          "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r3e7e0b40-026d-43d0-8281-9e0dc11ae674",
           "label": {
             "en": [
               "[ambience]"
@@ -445,13 +427,13 @@
           "items": [
             {
               "type": "Canvas",
-              "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/2#t=0,32.89"
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/2#t=0,32.89"
             }
           ]
         },
         {
           "type": "Range",
-          "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/range/rf7350bab-17b7-4b7d-858e-e8c83e8cef7a",
+          "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/rf7350bab-17b7-4b7d-858e-e8c83e8cef7a",
           "label": {
             "it": [
               "Gaetano Donizetti, L'Elisir D'Amore"
@@ -460,7 +442,7 @@
           "items": [
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/range/rdedd2c01-86be-4f7b-bfcc-586848bb0cd0",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/rdedd2c01-86be-4f7b-bfcc-586848bb0cd0",
               "label": {
                 "it": [
                   "Atto Secondo – Coro d’Introduzione – Cantiamo, facciam brindisi"
@@ -469,13 +451,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/2#t=32.89,169.04"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/2#t=32.89,169.04"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/range/r00d145d8-7bd7-4077-be4c-247cc026c811",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r00d145d8-7bd7-4077-be4c-247cc026c811",
               "label": {
                 "it": [
                   "Atto Secondo – Recitativo – Poiché cantar vi alletta"
@@ -484,13 +466,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/2#t=169.04,216.92"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/2#t=169.04,216.92"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/range/r1c7aa4ff-9200-475c-9df5-61618c0fec35",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r1c7aa4ff-9200-475c-9df5-61618c0fec35",
               "label": {
                 "it": [
                   "Atto Secondo – Barcarola a due voci – Io son ricco e tu sei bella"
@@ -499,13 +481,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/2#t=216.92,359.78"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/2#t=216.92,359.78"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/range/rc31de5e6-0db6-4893-8383-af6fbf429f7a",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/rc31de5e6-0db6-4893-8383-af6fbf429f7a",
               "label": {
                 "it": [
                   "Atto Secondo – Recotativo – Silenzio! È qua il notaro"
@@ -514,13 +496,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/2#t=359.78,561.76"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/2#t=359.78,561.76"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/range/r97bfe0c8-0fed-4c8a-9412-fefec5c891fc",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r97bfe0c8-0fed-4c8a-9412-fefec5c891fc",
               "label": {
                 "it": [
                   "Atto Secondo – Scena e Duetto – La donna è en animale stravagante – Venti scudi"
@@ -529,13 +511,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/2#t=561.76,1047.88"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/2#t=561.76,1047.88"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/range/r8e68d5c5-6931-4532-ac1b-212f437ce89b",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r8e68d5c5-6931-4532-ac1b-212f437ce89b",
               "label": {
                 "it": [
                   "Atto Secondo – Coro – Saria possibil?"
@@ -544,13 +526,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/2#t=1047.88,1283.02"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/2#t=1047.88,1283.02"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/range/re14797a3-4222-4922-814a-a4fa12f989ea",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/re14797a3-4222-4922-814a-a4fa12f989ea",
               "label": {
                 "it": [
                   "Atto Secondo – Quartetto – Dell’elisir mirabile"
@@ -559,13 +541,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/2#t=1283.02,1686.90"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/2#t=1283.02,1686.90"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/range/re0591627-b002-4dec-a579-cc01b12b30d4",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/re0591627-b002-4dec-a579-cc01b12b30d4",
               "label": {
                 "it": [
                   "Atto Secondo – Recitativo e Duetto – Come sen va contento! – Quanto amore!"
@@ -574,13 +556,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/2#t=1686.90,2162.01"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/2#t=1686.90,2162.01"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/range/ra6cec2bb-4028-4f34-bcf5-3406d5252853",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/ra6cec2bb-4028-4f34-bcf5-3406d5252853",
               "label": {
                 "it": [
                   "Atto Secondo – Romanza – Una furtiva lagrima"
@@ -589,13 +571,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/2#t=2162.01,2441.03"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/2#t=2162.01,2441.03"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/range/r7ec19a5a-e1cc-4db1-ab96-0ad578b90cc9",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r7ec19a5a-e1cc-4db1-ab96-0ad578b90cc9",
               "label": {
                 "it": [
                   "Atto Secondo – Recitativo ed Aria - Eccola – Prendi, Per me sei Libero"
@@ -604,13 +586,13 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/2#t=2441.03,2969.77"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/2#t=2441.03,2969.77"
                 }
               ]
             },
             {
               "type": "Range",
-              "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/range/r2b320d47-3996-4901-9322-808583958672",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r2b320d47-3996-4901-9322-808583958672",
               "label": {
                 "it": [
                   "Atto Secondo – Recitativo – Aria e Finale II - Alto! – Fronte! – Eli corregge ogni difetto"
@@ -619,7 +601,7 @@
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/2#t=2969.77,3307.22"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/2#t=2969.77,3307.22"
                 }
               ]
             }

--- a/recipe/0065-opera-multiple-canvases/manifest.json
+++ b/recipe/0065-opera-multiple-canvases/manifest.json
@@ -2,27 +2,8 @@
   "@context": "http://iiif.io/api/presentation/3/context.json",
   "type": "Manifest",
   "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}",
-  "label": {
-    "it": [
-      "L'elisir d'amore"
-    ],
-    "en": [
-      "The elixir of love"
-    ]
-  },
+  "label": { "it": [ "L'elisir d'amore" ], "en": [ "The elixir of love" ] },
   "metadata": [
-    {
-      "label": {
-        "en": [
-          "Creator"
-        ]
-      },
-      "value": {
-        "en": [
-          "See Other Contributors"
-        ]
-      }
-    },
     {
       "label": {
         "en": [
@@ -71,56 +52,6 @@
           "Indiana University Jacobs School of Music"
         ]
       }
-    },
-    {
-      "label": {
-        "en": [
-          "Subject"
-        ]
-      },
-      "value": {
-        "en": [
-          "Operas"
-        ]
-      }
-    },
-    {
-      "label": {
-        "en": [
-          "Genre"
-        ]
-      },
-      "value": {
-        "en": [
-          "Operas.",
-          "Filmed performances.",
-          "Live sound recordings."
-        ]
-      }
-    },
-    {
-      "label": {
-        "en": [
-          "Topical Subject"
-        ]
-      },
-      "value": {
-        "en": [
-          "Operas"
-        ]
-      }
-    }
-  ],
-  "homepage": [
-    {
-      "id": "https://purl.dlib.indiana.edu/iudl/media/q085549g74",
-      "type": "Text",
-      "label": {
-        "en": [
-          "View in Repository"
-        ]
-      },
-      "format": "text/html"
     }
   ],
   "items": [
@@ -142,7 +73,7 @@
               "motivation": "painting",
               "target": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1",
               "body": {
-                "id": "https://iiif-av.s3.amazonaws.com/examples/indiana/donizetti-elixir/vae0637_accessH264_low_act_1.mp4",
+                "id": "https://fixtures.iiif.io/video/indiana/donizetti-elixir/vae0637_accessH264_low_act_1.mp4",
                 "type": "Video",
                 "format": "video/mp4",
                 "height": 1080,
@@ -151,6 +82,12 @@
               }
             }
           ]
+        }
+      ],
+      "thumbnail": [
+        {
+          "id": "https://media.dlib.indiana.edu/master_files/vt150p78b/thumbnail",
+          "type": "Image"
         }
       ]
     },
@@ -172,7 +109,7 @@
               "motivation": "painting",
               "target": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/2",
               "body": {
-                "id": "https://iiif-av.s3.amazonaws.com/examples/indiana/donizetti-elixir/vae0637_accessH264_low_act_2.mp4",
+                "id": "https://fixtures.iiif.io/video/indiana/donizetti-elixir/vae0637_accessH264_low_act_2.mp4",
                 "type": "Video",
                 "format": "video/mp4",
                 "height": 1080,
@@ -181,6 +118,12 @@
               }
             }
           ]
+        }
+      ],
+      "thumbnail": [
+        {
+          "id": "https://media.dlib.indiana.edu/master_files/vt150p78b/thumbnail",
+          "type": "Image"
         }
       ]
     }
@@ -197,25 +140,10 @@
       "items": [
         {
           "type": "Range",
-          "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r764d8a04-47a4-4aa5-bc68-a572ad33866a",
-          "label": {
-            "en": [
-              "[ambience]"
-            ]
-          },
-          "items": [
-            {
-              "type": "Canvas",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=0.0,26.17"
-            }
-          ]
-        },
-        {
-          "type": "Range",
           "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/raa6a9c5b-79be-4d73-a3fc-2cb22e9e6618",
           "label": {
             "it": [
-              "Gaetano Donizetti, L'Elisir D'Amore"
+              "Gaetano Donizetti, L'Elisir D'Amore, Atto Primo"
             ]
           },
           "items": [
@@ -224,13 +152,13 @@
               "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r2ceb895e-a290-43b6-9351-f1fc8bad336c",
               "label": {
                 "it": [
-                  "Atto Primo – Preludio e Coro d'introduzione – Bel conforto al mietitore"
+                  "Preludio e Coro d'introduzione – Bel conforto al mietitore"
                 ]
               },
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=26.17,302.05"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=0,302.05"
                 }
               ]
             },
@@ -238,196 +166,16 @@
               "type": "Range",
               "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r5061e574-e6c6-4e04-93ea-368f8afab78b",
               "label": {
-                "it": [
-                  "Atto Primo – Cavatoma – Quanto é cara!"
+                "en": [
+                  "Remainder of Act I"
                 ]
               },
               "items": [
                 {
                   "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=302.05,488.23"
+                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=302.05,3971.24"
                 }
               ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r2f07821a-33c0-49c3-8e28-2fa3bcdf1349",
-              "label": {
-                "it": [
-                  "Atto Primo – Cavatina - Benedette queste carte! – Della crudele Isotta"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=488.23,770.29"
-                }
-              ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/rf2a0a534-4e5f-4280-a572-0f6b4d64246d",
-              "label": {
-                "it": [
-                  "Atto Primo – Cavatina e Stretta d’introduzione – Come Paride vezzoso"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=770.29,1278.04"
-                }
-              ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r40dee6f3-6df4-42cc-b71c-7536d26df61e",
-              "label": {
-                "it": [
-                  "Atto Primo – Recitativo – Intanto, o mia ragazza"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=1278.04,1314.05"
-                }
-              ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/rffadb10b-f45f-4f37-8566-cac50783f77c",
-              "label": {
-                "it": [
-                  "Atto Primo – Scene e Duetto – Una parola, o Adina – Chiedi all’aura lushinghiera"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=1314.05,1738.15"
-                }
-              ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/rf072516a-868d-4bf1-86b4-bba2951689ec",
-              "label": {
-                "it": [
-                  "Atto Primo – Coro – Che vuol dire codesta sonata?"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=1738.15,1855.24"
-                }
-              ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r05fc5414-d4c9-416c-bb08-44aabde33a63",
-              "label": {
-                "it": [
-                  "Atto Primo – Cavatina – Udite, udite, o rustici"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=1855.24,2288.23"
-                }
-              ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r60d2be49-2651-47da-9018-fb31758314ab",
-              "label": {
-                "it": [
-                  "Atto Primo – Recitavio, Scena e Duetto – Ardir! – Voglio dire"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=2288.23,2705.21"
-                }
-              ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r23b13c8a-27d1-416f-ba25-f71a7947a0b7",
-              "label": {
-                "it": [
-                  "Atto Primo – Recitavio – Caro Elisir! sei mio!"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=2705.21,2847.14"
-                }
-              ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r04634ffa-bf37-4537-80e4-cf0d7919666a",
-              "label": {
-                "it": [
-                  "Atto Primo – Scene e Duetto – Lallarallarà, la, la – Esulti pur la Barbara"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=2847.14,3174.16"
-                }
-              ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r95c31349-5bc1-4c4f-8fc1-7ff4e34133dc",
-              "label": {
-                "it": [
-                  "Atto Primo – Terzetto – In Guerra ed in amore"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=3174.16,3370.2"
-                }
-              ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/re9d2963f-ed54-4ff8-9f0f-19e2be05bf0e",
-              "label": {
-                "it": [
-                  "Atto Primo – Quartetto e Stretta del Finale I – Signor sergente – Adina, credimi"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/1#t=3370.2,3971.24"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "Range",
-          "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r3e7e0b40-026d-43d0-8281-9e0dc11ae674",
-          "label": {
-            "en": [
-              "[ambience]"
-            ]
-          },
-          "items": [
-            {
-              "type": "Canvas",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/2#t=0,32.89"
             }
           ]
         },
@@ -436,184 +184,17 @@
           "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/rf7350bab-17b7-4b7d-858e-e8c83e8cef7a",
           "label": {
             "it": [
-              "Gaetano Donizetti, L'Elisir D'Amore"
+              "Gaetano Donizetti, L'Elisir D'Amore, Atto Secondo"
             ]
           },
           "items": [
             {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/rdedd2c01-86be-4f7b-bfcc-586848bb0cd0",
-              "label": {
-                "it": [
-                  "Atto Secondo – Coro d’Introduzione – Cantiamo, facciam brindisi"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/2#t=32.89,169.04"
-                }
-              ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r00d145d8-7bd7-4077-be4c-247cc026c811",
-              "label": {
-                "it": [
-                  "Atto Secondo – Recitativo – Poiché cantar vi alletta"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/2#t=169.04,216.92"
-                }
-              ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r1c7aa4ff-9200-475c-9df5-61618c0fec35",
-              "label": {
-                "it": [
-                  "Atto Secondo – Barcarola a due voci – Io son ricco e tu sei bella"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/2#t=216.92,359.78"
-                }
-              ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/rc31de5e6-0db6-4893-8383-af6fbf429f7a",
-              "label": {
-                "it": [
-                  "Atto Secondo – Recotativo – Silenzio! È qua il notaro"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/2#t=359.78,561.76"
-                }
-              ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r97bfe0c8-0fed-4c8a-9412-fefec5c891fc",
-              "label": {
-                "it": [
-                  "Atto Secondo – Scena e Duetto – La donna è en animale stravagante – Venti scudi"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/2#t=561.76,1047.88"
-                }
-              ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r8e68d5c5-6931-4532-ac1b-212f437ce89b",
-              "label": {
-                "it": [
-                  "Atto Secondo – Coro – Saria possibil?"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/2#t=1047.88,1283.02"
-                }
-              ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/re14797a3-4222-4922-814a-a4fa12f989ea",
-              "label": {
-                "it": [
-                  "Atto Secondo – Quartetto – Dell’elisir mirabile"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/2#t=1283.02,1686.90"
-                }
-              ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/re0591627-b002-4dec-a579-cc01b12b30d4",
-              "label": {
-                "it": [
-                  "Atto Secondo – Recitativo e Duetto – Come sen va contento! – Quanto amore!"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/2#t=1686.90,2162.01"
-                }
-              ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/ra6cec2bb-4028-4f34-bcf5-3406d5252853",
-              "label": {
-                "it": [
-                  "Atto Secondo – Romanza – Una furtiva lagrima"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/2#t=2162.01,2441.03"
-                }
-              ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r7ec19a5a-e1cc-4db1-ab96-0ad578b90cc9",
-              "label": {
-                "it": [
-                  "Atto Secondo – Recitativo ed Aria - Eccola – Prendi, Per me sei Libero"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/2#t=2441.03,2969.77"
-                }
-              ]
-            },
-            {
-              "type": "Range",
-              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/range/r2b320d47-3996-4901-9322-808583958672",
-              "label": {
-                "it": [
-                  "Atto Secondo – Recitativo – Aria e Finale II - Alto! – Fronte! – Eli corregge ogni difetto"
-                ]
-              },
-              "items": [
-                {
-                  "type": "Canvas",
-                  "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/2#t=2969.77,3307.22"
-                }
-              ]
+              "type": "Canvas",
+              "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}/canvas/2#t=0,3307.22"
             }
           ]
         }
       ]
-    }
-  ],
-  "thumbnail": [
-    {
-      "id": "https://media.dlib.indiana.edu/master_files/vt150p78b/thumbnail",
-      "type": "Image"
     }
   ]
 }

--- a/recipe/0065-opera-multiple-canvases/manifest.json
+++ b/recipe/0065-opera-multiple-canvases/manifest.json
@@ -1,0 +1,637 @@
+{
+  "@context": [
+    "http://www.w3.org/ns/anno.jsonld",
+    "http://iiif.io/api/presentation/3/context.json"
+  ],
+  "type": "Manifest",
+  "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest",
+  "label": {
+    "it": [
+      "L'elisir d'amore"
+    ],
+    "en": [
+      "The elixir of love"
+    ]
+  },
+  "metadata": [
+    {
+      "label": {
+        "en": [
+          "Title"
+        ]
+      },
+      "value": {
+        "it": [
+          "L'elisir d'amore"
+        ],
+        "en": [
+          "The elixir of love"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Creator"
+        ]
+      },
+      "value": {
+        "en": [
+          "See Other Contributors"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Date Issued"
+        ]
+      },
+      "value": {
+        "en": [
+          "2019"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Contributor"
+        ]
+      },
+      "value": {
+        "en": [
+          "Romani, Felice, 1788-1865",
+          "Neely, David",
+          "Boyd, Spencer (Spencer Lawrence)",
+          "Boettcher, Avery",
+          "Sandes, Bruno",
+          "Ceballos de la Mora, Ricardo",
+          "Webber, Savanna",
+          "Porter, John Christopher",
+          "Brovsky, Linda",
+          "O'Hearn, Robert",
+          "Tzvetkov, Dana",
+          "Hase, Thomas C.",
+          "Siena, Daniela",
+          "Indiana University Opera Theater"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Publisher"
+        ]
+      },
+      "value": {
+        "en": [
+          "Indiana University Jacobs School of Music"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Subject"
+        ]
+      },
+      "value": {
+        "en": [
+          "Operas"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Genre"
+        ]
+      },
+      "value": {
+        "en": [
+          "Operas.",
+          "Filmed performances.",
+          "Live sound recordings."
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Topical Subject"
+        ]
+      },
+      "value": {
+        "en": [
+          "Operas"
+        ]
+      }
+    }
+  ],
+  "homepage": [
+    {
+      "id": "https://purl.dlib.indiana.edu/iudl/media/q085549g74",
+      "type": "Text",
+      "label": {
+        "en": [
+          "View in Repository"
+        ]
+      },
+      "format": "text/html"
+    }
+  ],
+  "items": [
+    {
+      "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/1",
+      "type": "Canvas",
+      "width": 1920,
+      "height": 1080,
+      "duration": 3971.24,
+      "label": { "en": [ "Act I" ] },
+      "items": [
+        {
+          "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/1/annotation_page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/1/annotation_page/1/annotation/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/1",
+              "body": {
+                "id": "https://iiif-av.s3.amazonaws.com/examples/indiana/donizetti-elixir/vae0637_accessH264_low_act_1.mp4",
+                "type": "Video",
+                "format": "video/mp4",
+                "height": 1080,
+                "width": 1920,
+                "duration": 3971.24
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/2",
+      "type": "Canvas",
+      "width": 1920,
+      "height": 1080,
+      "duration": 3307.22,
+      "label": { "en": [ "Act II" ] },
+      "items": [
+        {
+          "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/2/annotation_page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/2/annotation_page/1/annotation/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/2",
+              "body": {
+                "id": "https://iiif-av.s3.amazonaws.com/examples/indiana/donizetti-elixir/vae0637_accessH264_low_act_2.mp4",
+                "type": "Video",
+                "format": "video/mp4",
+                "height": 1080,
+                "width": 1920,
+                "duration": 3307.22
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "structures": [
+    {
+      "type": "Range",
+      "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/range/r9ad47417-1344-4991-a41a-b084c69a12d4",
+      "label": {
+        "en": [
+          "IU Opera Theatre"
+        ]
+      },
+      "items": [
+        {
+          "type": "Range",
+          "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/range/r764d8a04-47a4-4aa5-bc68-a572ad33866a",
+          "label": {
+            "en": [
+              "[ambience]"
+            ]
+          },
+          "items": [
+            {
+              "type": "Canvas",
+              "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/1#t=0.0,26.17"
+            }
+          ]
+        },
+        {
+          "type": "Range",
+          "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/range/raa6a9c5b-79be-4d73-a3fc-2cb22e9e6618",
+          "label": {
+            "it": [
+              "Gaetano Donizetti, L'Elisir D'Amore"
+            ]
+          },
+          "items": [
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/range/r2ceb895e-a290-43b6-9351-f1fc8bad336c",
+              "label": {
+                "it": [
+                  "Atto Primo – Preludio e Coro d'introduzione – Bel conforto al mietitore"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/1#t=26.17,302.05"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/range/r5061e574-e6c6-4e04-93ea-368f8afab78b",
+              "label": {
+                "it": [
+                  "Atto Primo – Cavatoma – Quanto é cara!"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/1#t=302.05,488.23"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/range/r2f07821a-33c0-49c3-8e28-2fa3bcdf1349",
+              "label": {
+                "it": [
+                  "Atto Primo – Cavatina - Benedette queste carte! – Della crudele Isotta"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/1#t=488.23,770.29"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/range/rf2a0a534-4e5f-4280-a572-0f6b4d64246d",
+              "label": {
+                "it": [
+                  "Atto Primo – Cavatina e Stretta d’introduzione – Come Paride vezzoso"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/1#t=770.29,1278.04"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/range/r40dee6f3-6df4-42cc-b71c-7536d26df61e",
+              "label": {
+                "it": [
+                  "Atto Primo – Recitativo – Intanto, o mia ragazza"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/1#t=1278.04,1314.05"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/range/rffadb10b-f45f-4f37-8566-cac50783f77c",
+              "label": {
+                "it": [
+                  "Atto Primo – Scene e Duetto – Una parola, o Adina – Chiedi all’aura lushinghiera"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/1#t=1314.05,1738.15"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/range/rf072516a-868d-4bf1-86b4-bba2951689ec",
+              "label": {
+                "it": [
+                  "Atto Primo – Coro – Che vuol dire codesta sonata?"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/1#t=1738.15,1855.24"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/range/r05fc5414-d4c9-416c-bb08-44aabde33a63",
+              "label": {
+                "it": [
+                  "Atto Primo – Cavatina – Udite, udite, o rustici"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/1#t=1855.24,2288.23"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/range/r60d2be49-2651-47da-9018-fb31758314ab",
+              "label": {
+                "it": [
+                  "Atto Primo – Recitavio, Scena e Duetto – Ardir! – Voglio dire"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/1#t=2288.23,2705.21"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/range/r23b13c8a-27d1-416f-ba25-f71a7947a0b7",
+              "label": {
+                "it": [
+                  "Atto Primo – Recitavio – Caro Elisir! sei mio!"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/1#t=2705.21,2847.14"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/range/r04634ffa-bf37-4537-80e4-cf0d7919666a",
+              "label": {
+                "it": [
+                  "Atto Primo – Scene e Duetto – Lallarallarà, la, la – Esulti pur la Barbara"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/1#t=2847.14,3174.16"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/range/r95c31349-5bc1-4c4f-8fc1-7ff4e34133dc",
+              "label": {
+                "it": [
+                  "Atto Primo – Terzetto – In Guerra ed in amore"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/1#t=3174.16,3370.2"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/range/re9d2963f-ed54-4ff8-9f0f-19e2be05bf0e",
+              "label": {
+                "it": [
+                  "Atto Primo – Quartetto e Stretta del Finale I – Signor sergente – Adina, credimi"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/1#t=3370.2,3971.24"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Range",
+          "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/range/r3e7e0b40-026d-43d0-8281-9e0dc11ae674",
+          "label": {
+            "en": [
+              "[ambience]"
+            ]
+          },
+          "items": [
+            {
+              "type": "Canvas",
+              "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/2#t=0,32.89"
+            }
+          ]
+        },
+        {
+          "type": "Range",
+          "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/range/rf7350bab-17b7-4b7d-858e-e8c83e8cef7a",
+          "label": {
+            "it": [
+              "Gaetano Donizetti, L'Elisir D'Amore"
+            ]
+          },
+          "items": [
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/range/rdedd2c01-86be-4f7b-bfcc-586848bb0cd0",
+              "label": {
+                "it": [
+                  "Atto Secondo – Coro d’Introduzione – Cantiamo, facciam brindisi"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/2#t=32.89,169.04"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/range/r00d145d8-7bd7-4077-be4c-247cc026c811",
+              "label": {
+                "it": [
+                  "Atto Secondo – Recitativo – Poiché cantar vi alletta"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/2#t=169.04,216.92"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/range/r1c7aa4ff-9200-475c-9df5-61618c0fec35",
+              "label": {
+                "it": [
+                  "Atto Secondo – Barcarola a due voci – Io son ricco e tu sei bella"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/2#t=216.92,359.78"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/range/rc31de5e6-0db6-4893-8383-af6fbf429f7a",
+              "label": {
+                "it": [
+                  "Atto Secondo – Recotativo – Silenzio! È qua il notaro"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/2#t=359.78,561.76"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/range/r97bfe0c8-0fed-4c8a-9412-fefec5c891fc",
+              "label": {
+                "it": [
+                  "Atto Secondo – Scena e Duetto – La donna è en animale stravagante – Venti scudi"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/2#t=561.76,1047.88"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/range/r8e68d5c5-6931-4532-ac1b-212f437ce89b",
+              "label": {
+                "it": [
+                  "Atto Secondo – Coro – Saria possibil?"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/2#t=1047.88,1283.02"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/range/re14797a3-4222-4922-814a-a4fa12f989ea",
+              "label": {
+                "it": [
+                  "Atto Secondo – Quartetto – Dell’elisir mirabile"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/2#t=1283.02,1686.90"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/range/re0591627-b002-4dec-a579-cc01b12b30d4",
+              "label": {
+                "it": [
+                  "Atto Secondo – Recitativo e Duetto – Come sen va contento! – Quanto amore!"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/2#t=1686.90,2162.01"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/range/ra6cec2bb-4028-4f34-bcf5-3406d5252853",
+              "label": {
+                "it": [
+                  "Atto Secondo – Romanza – Una furtiva lagrima"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/2#t=2162.01,2441.03"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/range/r7ec19a5a-e1cc-4db1-ab96-0ad578b90cc9",
+              "label": {
+                "it": [
+                  "Atto Secondo – Recitativo ed Aria - Eccola – Prendi, Per me sei Libero"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/2#t=2441.03,2969.77"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/range/r2b320d47-3996-4901-9322-808583958672",
+              "label": {
+                "it": [
+                  "Atto Secondo – Recitativo – Aria e Finale II - Alto! – Fronte! – Eli corregge ogni difetto"
+                ]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://example.org/iiif/cookbook-recipes/0065-opera-multiple-canvases/manifest/canvas/2#t=2969.77,3307.22"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "thumbnail": [
+    {
+      "id": "https://media.dlib.indiana.edu/master_files/vt150p78b/thumbnail",
+      "type": "Image"
+    }
+  ]
+}


### PR DESCRIPTION
Attempt at implementing recipes #26, #64, and #65.  Use case and other notes could probably be fleshed out more but I was at a loss for words.

~Video files have been passed to Jon Dunn who will put them in the S3 bucket.  When that has happened the manifests will need to be updated and tested in a client like UV.~  

As they stand now, the manifests validate with the 3.0 validator.  I tested in the UV examples page and the three manifests playback but 64 and 65 are missing their homepage link and thumbnail images.  Additionally structural navigation isn't working for the multi canvas example.

Opera TOC: http://universalviewer.io/examples/#?c=&m=&s=&cv=&manifest=https%3A%2F%2Fraw.githubusercontent.com%2FIIIF%2Fcookbook-recipes%2F816cf76a414a2eda9f8468d83b22c6d058e55e38%2Frecipe%2F0026-toc-opera%2Fmanifest.json

Single canvas opera: http://universalviewer.io/examples/#?c=&m=&s=&cv=&manifest=https%3A%2F%2Fraw.githubusercontent.com%2FIIIF%2Fcookbook-recipes%2F816cf76a414a2eda9f8468d83b22c6d058e55e38%2Frecipe%2F0064-opera-one-canvas%2Fmanifest.json

Multi-canvas opera: http://universalviewer.io/examples/#?c=&m=&s=&cv=&rid=https%3A%2F%2Fexample.org%2Fiiif%2Fcookbook-recipes%2F0065-opera-multiple-canvases%2Fmanifest%2Frange%2Fr2f07821a-33c0-49c3-8e28-2fa3bcdf1349&manifest=https%3A%2F%2Fraw.githubusercontent.com%2FIIIF%2Fcookbook-recipes%2F816cf76a414a2eda9f8468d83b22c6d058e55e38%2Frecipe%2F0065-opera-multiple-canvases%2Fmanifest.json