### PR TITLE
Clean jekyll magic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ cache: bundler
 before_script:
   - bundle install
 script:
-  - bundle exec jekyll clean && bundle exec jekyll build  --baseurl /cookbook/$TRAVIS_BRANCH
+  - bundle exec jekyll clean && bundle exec jekyll build  --baseurl cookbook/$TRAVIS_BRANCH
 
 install:
   - chmod 755 $TRAVIS_BUILD_DIR/scripts/updatePullRequest.sh && export iiifsite=cookbook && $TRAVIS_BUILD_DIR/scripts/updatePullRequest.sh;

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ cache: bundler
 before_script:
   - bundle install
 script:
-  - bundle exec jekyll clean && bundle exec jekyll build  --baseurl cookbook/$TRAVIS_BRANCH
+  - bundle exec jekyll clean && bundle exec jekyll build  --baseurl /cookbook/$TRAVIS_BRANCH
 
 install:
   - chmod 755 $TRAVIS_BUILD_DIR/scripts/updatePullRequest.sh && export iiifsite=cookbook && $TRAVIS_BUILD_DIR/scripts/updatePullRequest.sh;

--- a/_plugins/json_generator.rb
+++ b/_plugins/json_generator.rb
@@ -1,0 +1,91 @@
+# Store extra variables that are useful in IIIF Manifests
+
+require "json"
+
+module Jekyll
+  class JsonGenerator < Jekyll::Generator
+    def generate(site)
+        json_files = Array.new;
+
+        site.static_files.delete_if do |sf|
+            next if not File.extname(sf.path) == ".json"
+
+            # get the dirname of file, but we don't need the site source
+            json_dir = File.dirname(sf.path.gsub(site.source, ""))
+            json_name = File.basename(sf.path)
+
+            # add ts file
+            json_files << JsonFile.new(site, site.source, json_dir, json_name)
+            # return true so this file gets removed from static_files
+            # we'll replace it with our own tsfile that implements
+            # it's own write
+            true
+        end
+
+        site.static_files.concat(json_files)
+    end
+  end
+  class JsonFile < Jekyll::StaticFile
+        def initialize(site, base, dir, name)
+			super(site, base, dir, name, nil)
+        end
+
+		def write(dest)
+            dest_path = destination(dest)
+            return false if File.exist?(dest_path) && !modified?
+            replacements = {
+                "id.url" => @site.config['url'].to_s + @site.config['baseurl'].to_s+ @dir.to_s + "/" + @name.to_s,
+                "id.basename" => @site.config['url'].to_s + @site.config['baseurl'].to_s+ @dir.to_s
+               # "id.url" => "http://test.com"
+            }
+
+            self.class.mtimes[path] = mtime
+
+            FileUtils.mkdir_p(File.dirname(dest_path))
+            FileUtils.rm(dest_path) if File.exist?(dest_path)
+            file = File.open path
+            data = JSON.load file
+            processHash(data, replacements)
+            File.open(dest_path,"w") do |f|
+              f.write(data.to_json)
+            end
+		end
+        def processHash(hash, replacements)
+          hash.each do |key,value|
+            if (value.is_a? String) 
+                hash[key] = processString(value, replacements)
+            end
+            if (value.is_a?(Hash)) 
+                processHash(value, replacements)
+            end
+            if (value.is_a?(Array)) 
+                processList(value, replacements)
+            end
+          end
+        end  
+        def processList(value, replacements) 
+            value.each do | object |
+                if (object.is_a? String) 
+                    processString(object, replacements)
+                    # TODO need to add this back into the array somehow
+                end
+                if (object.is_a?(Hash)) 
+                    processHash(object, replacements)
+                end
+                if (object.is_a?(Array)) 
+                    processList(object, replacements)
+                end
+            end
+        end
+        def processString(value, replacements)
+          if (value.include? "{{")
+                replacements.each do |replacement_key, replacement_value|
+                    if value.match(/{{[ ].*#{replacement_key}[ ].*}}/)
+                        return value.gsub(/{{[ ].*#{replacement_key}[ ].*}}/,replacement_value)
+                    end
+                end    
+            end
+            return value
+        end
+	end
+end

--- a/recipe/0000_template/manifest.json
+++ b/recipe/0000_template/manifest.json
@@ -1,8 +1,5 @@
 {
-    "@context": [
-      "http://www.w3.org/ns/anno.jsonld",
-      "http://iiif.io/api/presentation/{{ page.major }}/context.json"
-    ],
-    "id": "https://example.org/iiif/book1/manifest",
+    "@context": [ "http://iiif.io/api/presentation/3/context.json" ],
+    "id": "{{ id.basename }} ",
     "type": "Manifest" 
   }

--- a/recipe/0001-mvm-image/manifest.json
+++ b/recipe/0001-mvm-image/manifest.json
@@ -1,27 +1,21 @@
----
-layout: null
----
 {
-    "@context": [
-      "http://www.w3.org/ns/anno.jsonld",
-      "http://iiif.io/api/presentation/3/context.json"
-    ],
-    "id": "{{site.url }}{{ site.baseurl }}/{{ page.path}}",
+    "@context": "http://iiif.io/api/presentation/3/context.json",
+    "id": "{{ id.url }}",
     "type": "Manifest",
     "label": { "en": [ "Image 1" ] },
     "items": [
       {
-        "id": "{{site.url }}{{ site.baseurl }}{{page.dir}}/canvas/p1",
+        "id": "{{ id.basename }}/canvas/p1",
         "type": "Canvas",
         "height": 1800,
         "width": 1200,
         "items": [
           {
-            "id": "{{site.url }}{{ site.baseurl }}{{page.dir}}page/p1/1",
+            "id": "{{ id.basename }}/page/p1/1",
             "type": "AnnotationPage",
             "items": [
               {
-                "id": "{{site.url }}{{ site.baseurl }}{{page.dir}}annotation/p0001-image",
+                "id": "{{ id.basename }}/annotation/p0001-image",
                 "type": "Annotation",
                 "motivation": "painting",
                 "body": {
@@ -31,7 +25,7 @@ layout: null
                   "height": 1800,
                   "width": 1200
                 },
-                "target": "{{site.url }}{{ site.baseurl }}{{page.dir}}canvas/p1"
+                "target": "{{ id.basename }}/canvas/p1"
               }
             ]
           }

--- a/recipe/0004-canvas-size/manifest.json
+++ b/recipe/0004-canvas-size/manifest.json
@@ -23,7 +23,7 @@
                   "type": "Image",
                   "format": "image/jpg",
                   "height": 900,
-                  "width": 600,
+                  "width": 600
                 },
                 "target": "https://example.org/iiif/canvas-size/canvas1"
               }


### PR DESCRIPTION
Creating a plugin so we can have clear Jekyll identifiers and don't need front matter. Implemented the following jekyll variables:

Full URL to current file:
```
"id": "{{ id.url }}"
```

Full URL to current directory:
{{ id.basename }}