### PR TITLE
Fixing JSON formatting

### DIFF
--- a/_plugins/json_generator.rb
+++ b/_plugins/json_generator.rb
@@ -46,7 +46,7 @@ module Jekyll
             data = JSON.load file
             processHash(data, replacements)
             File.open(dest_path,"w") do |f|
-              f.write(data.to_json)
+              f.write(JSON.pretty_generate(data))
             end
 		end
         def processHash(hash, replacements)


### PR DESCRIPTION
If I don't format the JSON in the _site part of the website then it doesn't come through in the Javascript plugin.