### PR TITLE
Recipe #0009 — Simplest Manifest - Multiple Related Images (book, etc.)

### DIFF
--- a/_includes/links.md
+++ b/_includes/links.md
@@ -6,3 +6,4 @@
 
 [prezi3]: https://iiif.io/api/presentation/3 "IIIF Presentation API"
 [prezi3-languages]: https://iiif.io/api/presentation/3.0/#language-of-property-values "Language of Property Values"
+[prezi3-thumbnail]: https://iiif.io/api/presentation/3.0/#thumbnail "Thumbnail"

--- a/recipe/0009-book-1/index.md
+++ b/recipe/0009-book-1/index.md
@@ -27,7 +27,7 @@ As in the sample manifest below, you should also consider providing a [thumbnail
 
 ## Example
 
-[JSON-LD](manifest.json) | View in X | View in Y 
+[JSON-LD](manifest.json) | [View in Universal Viewer](https://universalviewer.io/uv.html?manifest={{id.path}}/manifest.json) 
 
 {: .line-numbers data-download-link data-download-link-label="Download me" data-src="manifest.json" }
 ```json

--- a/recipe/0009-book-1/index.md
+++ b/recipe/0009-book-1/index.md
@@ -27,7 +27,8 @@ As in the sample manifest below, you should also consider providing a [thumbnail
 
 ## Example
 
-[JSON-LD](manifest.json) | [View in Universal Viewer](https://universalviewer.io/uv.html?manifest={{id.path}}/manifest.json) 
+[JSON-LD](manifest.json)
+ | [View in Universal Viewer](https://universalviewer.io/uv.html?manifest={{ site.url }}{{ site.baseurl }}{{ page.url }}manifest.json) 
 
 {: .line-numbers data-download-link data-download-link-label="Download me" data-src="manifest.json" }
 ```json

--- a/recipe/0009-book-1/index.md
+++ b/recipe/0009-book-1/index.md
@@ -1,28 +1,28 @@
 ---
-title: Simplest Manifest - Multiple Related Images (Book, etc.)
+title: Multiple Related Images (Book, etc.)
 id: 9
 layout: recipe
 tags: [image, presentation]
-summary: "The simplest viable manifest for an object composed of a set of images (book, etc.)."
+summary: "A sample manifest for an object composed of a set of images (book, etc.)."
 ---
 
 
 ## Use Case
 
-The simplest viable Manifest for an object composed of a set of images. If you have an object consisting of multiple related images, this pattern turns it into a valid IIIF Presentation resource. In practice it could be any kind of compound object that may comprise a series of pages, surfaces or views (pages of a book, the two sides of a postcard, four cardinal views of a statue etc.).
+A sample Manifest for an object composed of a set of images (book, etc.). If you have an object consisting of a sequence of multiple related images, this pattern turns it into a valid IIIF Presentation resource. In practice it could be any kind of compound object that may comprise a series of pages, surfaces or views (pages of a book, the two sides of a postcard, four cardinal views of a statue etc.).
 
-The manifest's `items` property contains the list of canvases representing the ordered sequence of views that make up the digital object. By default, the included canvases are distinct views that should only be presented individually in the order they appear in `items`.
-
-The sample manifest below represents the digital surrogate of a part of a printed book, comprised of a frontispiece and a title page. It contains two canvases and each canvas is filled with the full size image of a page. In this case we have one view per page, but depending on the type of object and how it has been digitized, you could also have one view per double page spread or one view per side.
-
-The `label` property on a canvas is recommended: it is the human readable label for a given view and thus allows users to distinguish between the different images. It usually gives the page or folio numbers, or any other appropriate term to identify a particular view within the object. The `label` property can be fully internationalized (see also [Text in Multiple Languages][0006]).
+The sample manifest below represents the digital surrogate of a part of a printed book, starting with a frontispiece and a title page. It contains four canvases and each canvas is filled with the full size image of a page. In this case we have one view per page, but depending on the type of object and how it has been digitized, you could also have one view per double page spread or one view per side.
 
 
 ## Implementation notes
 
-Depending on the expected user experience and the nature of the physical object and its digital surrogate, you may use several hints to inform a client of the appropriate presentation order and layout behavior. The Presentation 3.0 specification defines features like `viewingDirection` (see also [Book (viewingDirection variations)][0010] recipe) and `behavior` (see also [Book (paging variations)][0011] recipe) that will affect the presentation of the object in a user interface.
+Since this manifest is meant to represent a printed book, it has the `behavior` value `paged`, thus indicating that it can be presented in a page-turning interface. But depending on the expected user experience and the nature of the physical object and its digital surrogate, you may use other hints to inform a client of the appropriate presentation order and layout behavior. The Presentation 3.0 specification defines other values for `behavior` (see also [Book (paging variations)][0011] recipe) and a `viewingDirection` property (see also [Book (viewingDirection variations)][0010] recipe) that will both affect the presentation of the object in a user interface.
 
-You should also consider providing a [thumbnail][[prezi3-thumbnail]] for each canvas, so that a client can render a grid view or a thumbnail strip efficiently, thus helping users to navigate within the object. This is a general good practice and it is especially recommended if you do not provide a IIIF Image API service for your images.
+The manifest's `items` property contains the list of canvases representing the ordered sequence of views that make up the digital object. Each Canvas conveys the correct aspect ratio for that view, whatever it is. The most common case for a book is to have one view per page, thus resulting in one image per Canvas.
+
+The `label` property on a canvas is recommended: it is the human readable label for a given view and thus allows users to distinguish between the different images. It usually gives the page or folio numbers, or any other appropriate term to identify a particular view within the object. The `label` property can be fully internationalized (see also [Text in Multiple Languages][0006]).
+
+As in the sample manifest below, you should also consider providing a [thumbnail][[prezi3-thumbnail]] for each canvas, so that a client can render a grid view or a thumbnail strip efficiently, thus helping users to navigate within the object. This is a general good practice and it is especially recommended if you do not provide a IIIF Image API service for your images.
 
 
 ## Example

--- a/recipe/0009-book-1/index.md
+++ b/recipe/0009-book-1/index.md
@@ -1,43 +1,42 @@
 ---
-title: Book (simplest, > 1 canvas)
+title: Simplest Manifest - Multiple Related Images (Book, etc.)
 id: 9
 layout: recipe
-tags: [tbc]
-summary: "tbc"
+tags: [image, presentation]
+summary: "The simplest viable manifest for an object composed of a set of images (book, etc.)."
 ---
 
 
 ## Use Case
 
-Why is this pattern is important?
+The simplest viable Manifest for an object composed of a set of images. If you have an object consisting of multiple related images, this pattern turns it into a valid IIIF Presentation resource. In practice it could be any kind of compound object that may comprise a series of pages, surfaces or views (pages of a book, the two sides of a postcard, four cardinal views of a statue etc.).
+
+The manifest's `items` property contains the list of canvases representing the ordered sequence of views that make up the digital object. By default, the included canvases are distinct views that should only be presented individually in the order they appear in `items`.
+
+In the example below, there are two canvases and each canvas is filled with the full size image of a particular view of the object. The `label` property on a canvas is the human readable label for that view. This property is recommended since it helps users to distinguish between the different images. The `label` property can be fully internationalized (see also [Text in Multiple Languages][0006]).
+
+
 
 ## Implementation notes
 
-How does one implement the pattern?
+Depending on the expected user experience and the nature of the physical object and its digital surrogate, you may use different hints to inform a client of the appropriate presentation order or layout behavior. The Presentation 3.0 specification defines features like `viewingDirection` (see also [Book (viewingDirection variations)][0010] recipe) and `behavior` (see also [Book (paging variations)][0011] recipe) that will affect the presentation of the object in a user interface.
 
-## Restrictions
 
-When is this pattern is usable / not usable? Is it deprecated? If it uses multiple specifications, which versions are needed, etc.? (Not present if not needed.)
 
 ## Example
 
-Describe in prose and provide examples, e.g.: 
+[JSON-LD](manifest.json) | View in X | View in Y 
 
-``` json-doc
-{
-  "@context": [
-    "http://www.w3.org/ns/anno.jsonld",
-    "http://iiif.io/api/presentation/{{ page.major }}/context.json"
-  ],
-  "id": "https://example.org/iiif/book1/manifest",
-  "type": "Manifest" 
-}
+{: .line-numbers data-download-link data-download-link-label="Download me" data-src="manifest.json" }
+```json
+```
 ```
 
 # Related recipes
 
-Provide a bulleted list of related recipes and why they are relevant.
-
+* [Simplest Manifest - Single Image File][0001]
+* [Book (viewingDirection variations)][0010]
+* [Book (paging variations)][0011]
 
 {% include acronyms.md %}
 {% include links.md %}

--- a/recipe/0009-book-1/index.md
+++ b/recipe/0009-book-1/index.md
@@ -13,14 +13,16 @@ The simplest viable Manifest for an object composed of a set of images. If you h
 
 The manifest's `items` property contains the list of canvases representing the ordered sequence of views that make up the digital object. By default, the included canvases are distinct views that should only be presented individually in the order they appear in `items`.
 
-In the example below, there are two canvases and each canvas is filled with the full size image of a particular view of the object. The `label` property on a canvas is the human readable label for that view. This property is recommended since it helps users to distinguish between the different images. The `label` property can be fully internationalized (see also [Text in Multiple Languages][0006]).
+The sample manifest below represents the digital surrogate of a part of a printed book, comprised of a frontispiece and a title page. It contains two canvases and each canvas is filled with the full size image of a page. In this case we have one view per page, but depending on the type of object and how it has been digitized, you could also have one view per double page spread or one view per side.
 
+The `label` property on a canvas is recommended: it is the human readable label for a given view and thus allows users to distinguish between the different images. It usually gives the page or folio numbers, or any other appropriate term to identify a particular view within the object. The `label` property can be fully internationalized (see also [Text in Multiple Languages][0006]).
 
 
 ## Implementation notes
 
-Depending on the expected user experience and the nature of the physical object and its digital surrogate, you may use different hints to inform a client of the appropriate presentation order or layout behavior. The Presentation 3.0 specification defines features like `viewingDirection` (see also [Book (viewingDirection variations)][0010] recipe) and `behavior` (see also [Book (paging variations)][0011] recipe) that will affect the presentation of the object in a user interface.
+Depending on the expected user experience and the nature of the physical object and its digital surrogate, you may use several hints to inform a client of the appropriate presentation order and layout behavior. The Presentation 3.0 specification defines features like `viewingDirection` (see also [Book (viewingDirection variations)][0010] recipe) and `behavior` (see also [Book (paging variations)][0011] recipe) that will affect the presentation of the object in a user interface.
 
+You should also consider providing a [thumbnail][[prezi3-thumbnail]] for each canvas, so that a client can render a grid view or a thumbnail strip efficiently, thus helping users to navigate within the object. This is a general good practice and it is especially recommended if you do not provide a IIIF Image API service for your images.
 
 
 ## Example

--- a/recipe/0009-book-1/manifest.json
+++ b/recipe/0009-book-1/manifest.json
@@ -2,14 +2,15 @@
   "@context": ["http://iiif.io/api/presentation/3/context.json"],
   "id": "{{ id.url }}",
   "type": "Manifest",
-  "label": { "en": [ "Simplest Manifest - Multiple Related Images (Book, etc.)" ] },
+  "label": { "en": [ "Multiple Related Images (Book, etc.)" ] },
+  "behavior": ["paged"],
   "items": [
     {
       "id": "{{ id.path }}/canvas/p1",
       "type": "Canvas",
       "label": { "en": [ "Frontispiece" ] },
-      "width": 1200,
-      "height": 1800,
+      "width": 3186,
+      "height": 4612,
       "items": [
         {
           "id": "{{ id.path }}/page/p1/1",
@@ -20,15 +21,22 @@
               "type": "Annotation",
               "motivation": "painting",
               "image": {
-                "id": "https://iiif.io/api/presentation/2.1/example/fixtures/resources/page1-full.png",
+                "id": "https://iiif.io/api/image/3.0/example/reference/59d09e6773341f28ea166e9f3c1e674f-gallica_ark_12148_bpt6k1526005v_f19/full/max/0/default.jpg",
                 "type": "Image",
                 "format": "image/jpeg",
-                "width": 1200,
-                "height": 1800
+                "width": 3186,
+                "height": 4612
               },
               "target": "{{ id.path }}/canvas/p1"
             }
           ]
+        }
+      ],
+      "thumbnail": [
+        {
+          "id": "https://iiif.io/api/image/3.0/example/reference/59d09e6773341f28ea166e9f3c1e674f-gallica_ark_12148_bpt6k1526005v_f19/full/,200/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg"
         }
       ]
     },
@@ -36,8 +44,8 @@
       "id": "{{ id.path }}/canvas/p2",
       "type": "Canvas",
       "label": { "en": [ "Title page" ] },
-      "width": 1200,
-      "height": 1800,
+      "width": 3204,
+      "height": 4613,
       "items": [
         {
           "id": "{{ id.path }}/page/p2/1",
@@ -48,15 +56,92 @@
               "type": "Annotation",
               "motivation": "painting",
               "image": {
-                "id": "https://iiif.io/api/presentation/2.1/example/fixtures/resources/page2-full.png",
+                "id": "https://iiif.io/api/image/3.0/example/reference/59d09e6773341f28ea166e9f3c1e674f-gallica_ark_12148_bpt6k1526005v_f20/full/max/0/default.jpg",
                 "type": "Image",
                 "format": "image/jpeg",
-                "width": 1200,
-                "height": 1800
+                "width": 3204,
+                "height": 4613
               },
               "target": "{{ id.path }}/canvas/p2"
             }
           ]
+        }
+      ],
+      "thumbnail": [
+        {
+          "id": "https://iiif.io/api/image/3.0/example/reference/59d09e6773341f28ea166e9f3c1e674f-gallica_ark_12148_bpt6k1526005v_f20/full/,200/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg"
+        }
+      ]
+    },
+    {
+      "id": "{{ id.path }}/canvas/p3",
+      "type": "Canvas",
+      "label": { "en": [ "Blank page" ] },
+      "width": 3174,
+      "height": 4578,
+      "items": [
+        {
+          "id": "{{ id.path }}/page/p3/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "{{ id.path }}/annotation/p0003-image",
+              "type": "Annotation",
+              "motivation": "painting",
+              "image": {
+                "id": "https://iiif.io/api/image/3.0/example/reference/59d09e6773341f28ea166e9f3c1e674f-gallica_ark_12148_bpt6k1526005v_f21/full/max/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "width": 3174,
+                "height": 4578
+              },
+              "target": "{{ id.path }}/canvas/p3"
+            }
+          ]
+        }
+      ],
+      "thumbnail": [
+        {
+          "id": "https://iiif.io/api/image/3.0/example/reference/59d09e6773341f28ea166e9f3c1e674f-gallica_ark_12148_bpt6k1526005v_f21/full/,200/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg"
+        }
+      ]
+    },
+    {
+      "id": "{{ id.path }}/canvas/p4",
+      "type": "Canvas",
+      "label": { "en": [ "Bookplate" ] },
+      "width": 3198,
+      "height": 4632,
+      "items": [
+        {
+          "id": "{{ id.path }}/page/p4/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "{{ id.path }}/annotation/p0004-image",
+              "type": "Annotation",
+              "motivation": "painting",
+              "image": {
+                "id": "https://iiif.io/api/image/3.0/example/reference/59d09e6773341f28ea166e9f3c1e674f-gallica_ark_12148_bpt6k1526005v_f22/full/max/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "width": 3198,
+                "height": 4632
+              },
+              "target": "{{ id.path }}/canvas/p4"
+            }
+          ]
+        }
+      ],
+      "thumbnail": [
+        {
+          "id": "https://iiif.io/api/image/3.0/example/reference/59d09e6773341f28ea166e9f3c1e674f-gallica_ark_12148_bpt6k1526005v_f22/full/,200/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg"
         }
       ]
     }

--- a/recipe/0009-book-1/manifest.json
+++ b/recipe/0009-book-1/manifest.json
@@ -1,0 +1,64 @@
+{
+  "@context": ["http://iiif.io/api/presentation/3/context.json"],
+  "id": "{{ id.url }}",
+  "type": "Manifest",
+  "label": { "en": [ "Simplest Manifest - Multiple Related Images (Book, etc.)" ] },
+  "items": [
+    {
+      "id": "{{ id.path }}/canvas/p1",
+      "type": "Canvas",
+      "label": { "en": [ "Image 1" ] },
+      "width": 1200,
+      "height": 1800,
+      "items": [
+        {
+          "id": "{{ id.path }}/page/p1/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "{{ id.path }}/annotation/p0001-image",
+              "type": "Annotation",
+              "motivation": "painting",
+              "image": {
+                "id": "https://iiif.io/api/presentation/2.1/example/fixtures/resources/page1-full.png",
+                "type": "Image",
+                "format": "image/jpeg",
+                "width": 1200,
+                "height": 1800
+              },
+              "target": "{{ id.path }}/canvas/p1"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "{{ id.path }}/canvas/p2",
+      "type": "Canvas",
+      "label": { "en": [ "Image 2" ] },
+      "width": 1200,
+      "height": 1800,
+      "items": [
+        {
+          "id": "{{ id.path }}/page/p2/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "{{ id.path }}/annotation/p0002-image",
+              "type": "Annotation",
+              "motivation": "painting",
+              "image": {
+                "id": "https://iiif.io/api/presentation/2.1/example/fixtures/resources/page2-full.png",
+                "type": "Image",
+                "format": "image/jpeg",
+                "width": 1200,
+                "height": 1800
+              },
+              "target": "{{ id.path }}/canvas/p2"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/recipe/0009-book-1/manifest.json
+++ b/recipe/0009-book-1/manifest.json
@@ -20,7 +20,7 @@
               "id": "{{ id.path }}/annotation/p0001-image",
               "type": "Annotation",
               "motivation": "painting",
-              "image": {
+              "body": {
                 "id": "https://iiif.io/api/image/3.0/example/reference/59d09e6773341f28ea166e9f3c1e674f-gallica_ark_12148_bpt6k1526005v_f19/full/max/0/default.jpg",
                 "type": "Image",
                 "format": "image/jpeg",
@@ -55,7 +55,7 @@
               "id": "{{ id.path }}/annotation/p0002-image",
               "type": "Annotation",
               "motivation": "painting",
-              "image": {
+              "body": {
                 "id": "https://iiif.io/api/image/3.0/example/reference/59d09e6773341f28ea166e9f3c1e674f-gallica_ark_12148_bpt6k1526005v_f20/full/max/0/default.jpg",
                 "type": "Image",
                 "format": "image/jpeg",
@@ -90,7 +90,7 @@
               "id": "{{ id.path }}/annotation/p0003-image",
               "type": "Annotation",
               "motivation": "painting",
-              "image": {
+              "body": {
                 "id": "https://iiif.io/api/image/3.0/example/reference/59d09e6773341f28ea166e9f3c1e674f-gallica_ark_12148_bpt6k1526005v_f21/full/max/0/default.jpg",
                 "type": "Image",
                 "format": "image/jpeg",
@@ -125,7 +125,7 @@
               "id": "{{ id.path }}/annotation/p0004-image",
               "type": "Annotation",
               "motivation": "painting",
-              "image": {
+              "body": {
                 "id": "https://iiif.io/api/image/3.0/example/reference/59d09e6773341f28ea166e9f3c1e674f-gallica_ark_12148_bpt6k1526005v_f22/full/max/0/default.jpg",
                 "type": "Image",
                 "format": "image/jpeg",

--- a/recipe/0009-book-1/manifest.json
+++ b/recipe/0009-book-1/manifest.json
@@ -7,7 +7,7 @@
     {
       "id": "{{ id.path }}/canvas/p1",
       "type": "Canvas",
-      "label": { "en": [ "Image 1" ] },
+      "label": { "en": [ "Frontispiece" ] },
       "width": 1200,
       "height": 1800,
       "items": [
@@ -35,7 +35,7 @@
     {
       "id": "{{ id.path }}/canvas/p2",
       "type": "Canvas",
-      "label": { "en": [ "Image 2" ] },
+      "label": { "en": [ "Title page" ] },
       "width": 1200,
       "height": 1800,
       "items": [


### PR DESCRIPTION
This PR is a first pass at addressing issue #9, creating recipe 9 : simplest manifest with multiple related Images (book, etc.)

TODO's:

- [x] add a sentence about the recommended use of `thumbnail` property into the implementations notes
- [x]  find a few sample images in Gallica or elsewhere (pages of a book...)
- [x] update the manifest: fixtures image urls, image and canvas sizes, canvas labels
- [x] add links to viewers
- [ ] check the viewers once the manifest is accessible via http
