### PR TITLE
Fixing viewer links

### DIFF
--- a/_includes/manifest_links.html
+++ b/_includes/manifest_links.html
@@ -1,2 +1,2 @@
 {% assign viewers = include.viewers | split: "," %}
-[JSON-LD](manifest.json) {% for viewerTxt in viewers %}{% assign viewer = viewerTxt | strip %}| {% include viewer_link.html type=viewer manifest=include.manifest %}{% endfor %}
+[JSON-LD]({{ include.manifest }}) {% for viewerTxt in viewers %}{% assign viewer = viewerTxt | strip %}| {% include viewer_link.html type=viewer manifest=include.manifest %}{% endfor %}

--- a/_includes/viewer_link.html
+++ b/_includes/viewer_link.html
@@ -7,7 +7,7 @@
 {% endcapture %}
 {% if include.type == 'UV' %}
     {% capture viewer_url %}
-        https://uv.netlify.app/#?c=&amp;m=&amp;s=&amp;cv=&amp;manifest={{manifest_url |strip}}
+        https://uv-v3.netlify.app/#?c=&amp;m=&amp;s=&amp;cv=&amp;manifest={{manifest_url |strip}}
     {% endcapture %}
     {% assign default_text="View in Universal Viewer" %}
 {% elsif include.type == 'Mirador' %}

--- a/recipe/0002-mvm-audio/index.md
+++ b/recipe/0002-mvm-audio/index.md
@@ -19,7 +19,7 @@ The implementation is identical to the [image example][0001], except that the co
 
 This example shows a Manifest with a single Canvas that lasts for 3600 seconds, or exactly one hour. It has a single audio file (audio-sample.mp4) which is associated with it. The mp4 also has a duration of exactly one hour.
 
-{% include manifest_links.html manifest="manifest.json" %}
+{% include manifest_links.html viewers="UV" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" %}
 


### PR DESCRIPTION
Making sure the JSON-LD link takes the manifest from the parameter and doesn't default to manifest.json. Also changing the version to uv-3 as this seems to work better with AV.