### PR TITLE
Adding license information for 30min clock

### DIFF
--- a/recipe/0003-mvm-video/index.md
+++ b/recipe/0003-mvm-video/index.md
@@ -17,7 +17,7 @@ The implementation is identical to the [image example][0001], except that the co
 
 ## Example
 
-This example shows a Manifest with a single Canvas that lasts for 1801 seconds, or just over 30 minutes. It has a single video file (30-minute-clock.mp4) which is associated with it. The mp4 also has a duration of 30 minutes. The video was created by [DrLex1](https://www.youtube.com/watch?v=Lsq0FiXjGHg) and was released using a [Creative Commons Attribution license](https://creativecommons.org/licenses/by/3.0/).
+This example shows a Manifest with a single Canvas that lasts for 572 seconds, or just under 10 minutes. It has a single video file (lunchroom_manners_1024kb.mp4) which is associated with it. The mp4 also has a duration of 572 seconds. 
 
 {% include manifest_links.html viewers="UV" manifest="manifest.json" %}
 

--- a/recipe/0003-mvm-video/index.md
+++ b/recipe/0003-mvm-video/index.md
@@ -17,7 +17,7 @@ The implementation is identical to the [image example][0001], except that the co
 
 ## Example
 
-This example shows a Manifest with a single Canvas that lasts for 1801 seconds, or just over 30 minutes. It has a single video file (30-minute-clock.mp4) which is associated with it. The mp4 also has a duration of 30 minutes.
+This example shows a Manifest with a single Canvas that lasts for 1801 seconds, or just over 30 minutes. It has a single video file (30-minute-clock.mp4) which is associated with it. The mp4 also has a duration of 30 minutes. The video was created by [DrLex1](https://www.youtube.com/watch?v=Lsq0FiXjGHg) and was released using a [Creative Commons Attribution license](https://creativecommons.org/licenses/by/3.0/).
 
 {% include manifest_links.html viewers="UV" manifest="manifest.json" %}
 

--- a/recipe/0003-mvm-video/manifest.json
+++ b/recipe/0003-mvm-video/manifest.json
@@ -9,7 +9,7 @@
         "type": "Canvas",
         "height": 360,
         "width": 640,
-        "duration": 1801.055,
+        "duration": 572.034,
         "items": [
           {
             "id": "{{ id.path }}/canvas/page",
@@ -20,11 +20,11 @@
                 "type": "Annotation",
                 "motivation": "painting",
                 "body": {
-                    "id": "https://fixtures.iiif.io/video/indiana/30-minute-clock/medium/30-minute-clock.mp4",
+                    "id": "https://fixtures.iiif.io/video/indiana/lunchroom_manners/high/lunchroom_manners_1024kb.mp4",
                     "type": "Video",
                     "height": 360,
-                    "width": 640,
-                    "duration": 1801.055,
+                    "width": 480,
+                    "duration": 572.034,
                     "format": "video/mp4"
                 },
                 "target": "{{ id.path }}/canvas"

--- a/recipe/0015-start/index.md
+++ b/recipe/0015-start/index.md
@@ -28,7 +28,7 @@ For more information on other Selector classes, see: [IIIF Open/Web Annotation E
 
 ## Example
 
-This example shows a Manifest with a single Canvas with a duration of 1801.055 seconds. It has a single video file (30-minute-clock.mp4) which is associated with it. The `start` property specifies a start point of 120.5 seconds into the playback.
+This example shows a Manifest with a single Canvas with a duration of 1801.055 seconds. It has a single video file (30-minute-clock.mp4) which is associated with it. The `start` property specifies a start point of 120.5 seconds into the playback. The video was created by [DrLex1](https://www.youtube.com/watch?v=Lsq0FiXjGHg) and was released using a [Creative Commons Attribution license](https://creativecommons.org/licenses/by/3.0/).
 
 *Note: As of the writing of this recipe, playback of video content is supported by some viewers (Universal Viewer), but the `start` property for time-based objects is not yet supported in viewers.*
 

--- a/recipe/0015-start/manifest.json
+++ b/recipe/0015-start/manifest.json
@@ -15,6 +15,19 @@
             "t": 120.5
         }
     },
+    "rights": "https://creativecommons.org/licenses/by/3.0/",
+    "requiredStatement": {
+        "label": {
+            "en": [
+                "Attribution"
+            ]
+        },
+        "value": {
+            "en": [
+                "<span>The video was created by <a href='https://www.youtube.com/watch?v=Lsq0FiXjGHg'>DrLex1</a> and was released using a <a href='https://creativecommons.org/licenses/by/3.0/'>Creative Commons Attribution license</a></span>"
+            ]
+        }
+    },
     "items": [
       {
         "id": "{{ id.path }}/canvas/segment1",

--- a/recipe/0015-start/manifest.json
+++ b/recipe/0015-start/manifest.json
@@ -15,7 +15,7 @@
             "t": 120.5
         }
     },
-    "rights": "https://creativecommons.org/licenses/by/3.0/",
+    "rights": "http://creativecommons.org/licenses/by/3.0/",
     "requiredStatement": {
         "label": {
             "en": [


### PR DESCRIPTION
It has been flagged that we should be referencing the license and author of the 30min video in the IIIF fixtures repository. This pull request adds this attribution and I will update the fixtures repo to say this is required. 

I don't think this needs TRC approval but I will flag it as a change to the TRC.