### PR TITLE
0251 fix manifest label

### DIFF
--- a/recipe/0013-placeholderCanvas/index.md
+++ b/recipe/0013-placeholderCanvas/index.md
@@ -30,7 +30,7 @@ _Note: The `placeholderCanvas` property is not yet supported in viewers._
 
 {% include manifest_links.html viewers="" manifest="manifest.json" %}
 
-{% include jsonviewer.html src="manifest.json" config="data-line='12-38'"%}
+{% include jsonviewer.html src="manifest.json" config="data-line='17-43'"%}
 
 # Related recipes
 

--- a/recipe/0013-placeholderCanvas/manifest.json
+++ b/recipe/0013-placeholderCanvas/manifest.json
@@ -2,6 +2,7 @@
     "@context": "http://iiif.io/api/presentation/3/context.json",
     "id": "{{ id.url }}",
     "type": "Manifest",
+	"label": { "en": [ "Video recording of Donizetti's _The Elixer of Love_" ] },
     "items": [
       {
         "id": "{{ id.path }}/canvas/donizetti",

--- a/recipe/0014-accompanyingcanvas/index.md
+++ b/recipe/0014-accompanyingcanvas/index.md
@@ -30,7 +30,7 @@ _Note: The `accompanyingCanvas` property is not yet supported in viewers._
 
 {% include manifest_links.html viewers="" manifest="manifest.json" %}
 
-{% include jsonviewer.html src="manifest.json" config="data-line='15-53'"%}
+{% include jsonviewer.html src="manifest.json" config="data-line='20-58'"%}
 
 # Related recipes
 

--- a/recipe/0014-accompanyingcanvas/manifest.json
+++ b/recipe/0014-accompanyingcanvas/manifest.json
@@ -2,7 +2,7 @@
 	"@context": "http://iiif.io/api/presentation/3/context.json",
 	"id": "{{ id.url }}",
 	"type": "Manifest",
-	"label": [ { "en": "Partial audio recording of Gustav Mahler's _Symphony No. 3_" } ],
+	"label": { "en": ["Partial audio recording of Gustav Mahler's _Symphony No. 3_"] },
 	"items": [
 		{
 			"id": "{{ id.path }}/canvas/p1",

--- a/recipe/0014-accompanyingcanvas/manifest.json
+++ b/recipe/0014-accompanyingcanvas/manifest.json
@@ -2,6 +2,7 @@
 	"@context": "http://iiif.io/api/presentation/3/context.json",
 	"id": "{{ id.url }}",
 	"type": "Manifest",
+	"label": [ { "en": "Partial audio recording of Gustav Mahler's _Symphony No. 3_" } ],
 	"items": [
 		{
 			"id": "{{ id.path }}/canvas/p1",


### PR DESCRIPTION
Addresses #251: Fixes originally mentioned recipe `0013-accompanying-canvas` as well as an additional one found in making that fix