### PR TITLE
Copyedit #5 for clarity and accuracy

### DIFF
--- a/recipe/0005-image-service/index.md
+++ b/recipe/0005-image-service/index.md
@@ -17,7 +17,7 @@ You have a rare or special object in your collection that you'd like to make ava
 
 ## Implementation Notes
 
-This property may attach to any IIIF resource type, and requires the use of `id` and `type`. The annotation structure follows that of the [Simplest Manifest - Image][0001] recipe. Within the `body` of the image annotation, specify the IIIF Image API service using the `service` property. The service's `id` property value is the base URI of that IIIF Image API service. 
+A service may be attached to any IIIF resource type, and requires at minumum the use of `id` and `type`. The annotation structure follows that of the [Simplest Manifest - Image][0001] recipe. Within the `body` of the image annotation, specify the IIIF Image API service using the `service` property. The service's `id` property value is the base URI of that IIIF Image API service. 
 
 The `type` tells the client what version of the IIIF Image API (1, 2, or 3) you are referencing. Values for `type` are defined in [the IIIF Registry of Services][service-registry] and include values for compatibility with other IIIF APIs. See [the service property in the IIIF Presentation specification][prezi3-service] for more information.
 


### PR DESCRIPTION
This pull request incorporates changes initiated by @robcast, pointing out that the Implementation Notes began discussion of the `service` property as 'this property' without an antecedent. In rereading, I thought it yet better to talk about the Image Service first rather than the property first. To be discussed among cookbook authors.﻿
