### PR TITLE
Add Mirador viewer to #234 `provider`

### DIFF
--- a/recipe/0234-provider/index.md
+++ b/recipe/0234-provider/index.md
@@ -5,6 +5,8 @@ layout: recipe
 tags: provider
 summary: "Include a rich set of information for each content contributor so clients can make this information visible."
 viewers:
+ - id: Mirador
+   support: partial
 topic: property
 property: provider
 ---
@@ -32,9 +34,9 @@ None known.
 
 In this example, we reuse the front page of a kabuki playbill that was contributed to the IIIF Cookbook by UCLA Library Digital Collections. The `id` for them as an Agent is the US Library of Congress authority ID for the UCLA Library, the `homepage` is their actual homepage, the `logo` is also for the library as a whole, and the `seeAlso` is the US Library of Congress MADS/XML. In your use of this property, you might want to and be able to unify the information in the property differently.
 
-No viewer currently implements `provider` sufficiently fully and correctly.
+Only Mirador implements `provider`, and only partially. The property must be on the Manifest level, and Mirador will only display the text in a `label` under `provider`.
 
-{% include manifest_links.html viewers="" manifest="manifest.json" %}
+{% include manifest_links.html viewers="Mirador" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" config='data-line="15-82"' %}
 

--- a/recipe/0234-provider/index.md
+++ b/recipe/0234-provider/index.md
@@ -34,7 +34,7 @@ None known.
 
 In this example, we reuse the front page of a kabuki playbill that was contributed to the IIIF Cookbook by UCLA Library Digital Collections. The `id` for them as an Agent is the US Library of Congress authority ID for the UCLA Library, the `homepage` is their actual homepage, the `logo` is also for the library as a whole, and the `seeAlso` is the US Library of Congress MADS/XML. In your use of this property, you might want to and be able to unify the information in the property differently.
 
-Only Mirador implements `provider`, and only partially. The property must be on the Manifest level, and Mirador will only display the text in a `label` under `provider`.
+Only Mirador implements `provider`, and only partially. The property must be on the Manifest level, Mirador will only display the text from a `label` under `provider`, and the information will only be found in the list of manifests.
 
 {% include manifest_links.html viewers="Mirador" manifest="manifest.json" %}
 


### PR DESCRIPTION
Mirador has partial support for `provider`. The implementation is limited enough that the cookbook authors should discuss to make sure it is sufficient to add Mirador as a viewer for the `provider` property.
Addresses #316 