### PR TITLE
Fixing no support for Manifest navPlace

### DIFF
--- a/recipe/0154-geo-extension/index.md
+++ b/recipe/0154-geo-extension/index.md
@@ -6,10 +6,7 @@ tags: [maps, geolocate, navPlace]
 summary: "Use the navPlace extension to provide geolocation information about an IIIF Presentation API 3.0 Manifest."
 layout: recipe
 viewers:
- - id: UV
-   support: none
- - id: Mirador
-   support: none
+
 ---
 
 ### Use Case


### PR DESCRIPTION
Currently the manifest navPlace recipe shows up in the matrix as partial but its actually none. This is due to the recipe having the following in the front matter:

```
viewers:
 - id: UV
   support: none
 - id: Mirador
   support: none
```

but if there is no support then the viewers should be empty. 