### PR TITLE
Address typos in Simplest Manifest - Audio

### DIFF
--- a/recipe/0002-mvm-audio/index.md
+++ b/recipe/0002-mvm-audio/index.md
@@ -23,7 +23,7 @@ The implementation is identical to the [image example][0001], except that the co
 
 ## Example
 
-This example shows a Manifest with a single Canvas that lasts for 3600 seconds, or exactly one hour. It has a single audio file (audio-sample.mp4) which is associated with it. The mp4 also has a duration of exactly one hour.
+This example shows a Manifest with a single Canvas that lasts for 1985.024 seconds. It has a single audio file (audio-sample.mp4) which is associated with it. The mp4 also has a duration of 1985.024 seconds.
 
 {% include manifest_links.html viewers="UV, Mirador" manifest="manifest.json" %}
 

--- a/recipe/0002-mvm-audio/manifest.json
+++ b/recipe/0002-mvm-audio/manifest.json
@@ -23,7 +23,7 @@
                 "format": "audio/mp4",
                 "duration": 1985.024
               },
-              "target": "{{ id.path }}/canvas/page"
+              "target": "{{ id.path }}/canvas"
             }
           ]
         }


### PR DESCRIPTION
This PR addresses issues noted in #351.

- Fix annotation to target canvas id.
- Fix duration reference typos.
