### PR TITLE
Add Clover to recipes.

### DIFF
--- a/_includes/viewer_link.html
+++ b/_includes/viewer_link.html
@@ -36,6 +36,11 @@
         {% endcapture %}
     {% endif %}
     {% assign default_text="View in Annona" %}
+{% elsif include.type == 'Clover' %}
+    {% capture viewer_url %}
+        https://samvera-labs.github.io/clover-iiif/?iiif-content={{manifest_url |strip}}
+    {% endcapture %}
+    {% assign default_text="View in Clover" %}
 {% else %}    
     {% capture default_text %}Unknown Viewer type '{{ include.type}}'{% endcapture %}
     {% capture viewer_url %}{{manifest_url |strip}}{% endcapture %}

--- a/recipe/0001-mvm-image/index.md
+++ b/recipe/0001-mvm-image/index.md
@@ -8,6 +8,7 @@ viewers:
  - Mirador
  - UV
  - Annona
+ - Clover
 topic: 
  - basic
  - image

--- a/recipe/0001-mvm-image/index.md
+++ b/recipe/0001-mvm-image/index.md
@@ -33,7 +33,7 @@ This recipe is not for large images or deep zoom functionality. For this, see th
 
 ## Example
 
-{% include manifest_links.html viewers="UV, Mirador, Annona" manifest="manifest.json" %}
+{% include manifest_links.html viewers="UV, Mirador, Annona, Clover" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" %}
 

--- a/recipe/0002-mvm-audio/index.md
+++ b/recipe/0002-mvm-audio/index.md
@@ -7,6 +7,7 @@ summary: "The simplest viable manifest for audio content. This pattern presents 
 viewers:
  - Mirador
  - UV
+ - Clover
 topic: 
  - basic
  - AV

--- a/recipe/0002-mvm-audio/index.md
+++ b/recipe/0002-mvm-audio/index.md
@@ -26,7 +26,7 @@ The implementation is identical to the [image example][0001], except that the co
 
 This example shows a Manifest with a single Canvas that lasts for 1985.024 seconds. It has a single audio file (audio-sample.mp4) which is associated with it. The mp4 also has a duration of 1985.024 seconds.
 
-{% include manifest_links.html viewers="UV, Mirador" manifest="manifest.json" %}
+{% include manifest_links.html viewers="UV, Mirador, Clover" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" %}
 

--- a/recipe/0003-mvm-video/index.md
+++ b/recipe/0003-mvm-video/index.md
@@ -26,7 +26,7 @@ The implementation is identical to the [image example][0001], except that the co
 
 This example shows a Manifest with a single Canvas that lasts for 572 seconds, or just under 10 minutes. It has a single video file (lunchroom_manners_1024kb.mp4) which is associated with it. The mp4 also has a duration of 572 seconds. 
 
-{% include manifest_links.html viewers="UV, Mirador" manifest="manifest.json" %}
+{% include manifest_links.html viewers="UV, Mirador, Clover" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" %}
 

--- a/recipe/0003-mvm-video/index.md
+++ b/recipe/0003-mvm-video/index.md
@@ -7,6 +7,7 @@ summary: "The simplest viable manifest for video content. This pattern presents 
 viewers:
  - Mirador
  - UV
+ - Clover
 topic: 
  - basic
  - AV

--- a/recipe/0005-image-service/index.md
+++ b/recipe/0005-image-service/index.md
@@ -33,7 +33,7 @@ Though a version 3 Manifest may specify a service using the version 2 `@id` and 
 
 ## Example
 
-{% include manifest_links.html viewers="Mirador, Annona" manifest="manifest.json" %}
+{% include manifest_links.html viewers="Mirador, Annona, Clover" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" config='data-line="36-42"' %}
 

--- a/recipe/0005-image-service/index.md
+++ b/recipe/0005-image-service/index.md
@@ -7,6 +7,7 @@ summary: "Paint a Canvas using an image with an associated IIIF Image API servic
 viewers:
  - Mirador
  - Annona
+ - Clover
 topic: 
  - basic 
  - image

--- a/recipe/0006-text-language/index.md
+++ b/recipe/0006-text-language/index.md
@@ -8,6 +8,7 @@ viewers:
  - UV
  - Mirador  
  - Annona
+ - Clover
 topic: basic
 property: label, summary, metadata, requiredStatement
 ---

--- a/recipe/0006-text-language/index.md
+++ b/recipe/0006-text-language/index.md
@@ -8,7 +8,6 @@ viewers:
  - UV
  - Mirador  
  - Annona
- - Clover
 topic: basic
 property: label, summary, metadata, requiredStatement
 ---

--- a/recipe/0007-string-formats/index.md
+++ b/recipe/0007-string-formats/index.md
@@ -29,7 +29,7 @@ For security reasons, clients allow only `a`, `b`, `br`, `i`, `img`, `p`, `small
 
 ## Example
 
-{% include manifest_links.html viewers="UV,Mirador,Annona" manifest="manifest.json" %}
+{% include manifest_links.html viewers="UV, Mirador, Annona, Clover" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" config='data-line="7,12,24,38"' %}
 

--- a/recipe/0007-string-formats/index.md
+++ b/recipe/0007-string-formats/index.md
@@ -8,6 +8,7 @@ viewers:
  - UV
  - Mirador  
  - Annona
+ - Clover
 topic: property
 property: label, summary, metadata, requiredStatement
 ---

--- a/recipe/0008-rights/index.md
+++ b/recipe/0008-rights/index.md
@@ -37,7 +37,7 @@ None known.
 
 ## Example
 
-{% include manifest_links.html viewers="UV, Mirador, Annona" manifest="manifest.json" %}
+{% include manifest_links.html viewers="UV, Mirador, Annona, Clover" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" config='data-line="15-27"' %}
 

--- a/recipe/0008-rights/index.md
+++ b/recipe/0008-rights/index.md
@@ -8,6 +8,7 @@ viewers:
  - UV
  - Mirador
  - Annona
+ - Clover
 topic: property
 property: rights, requiredStatement
 ---

--- a/recipe/0009-book-1/index.md
+++ b/recipe/0009-book-1/index.md
@@ -8,6 +8,7 @@ viewers:
  - UV
  - Mirador  
  - Annona
+ - Clover
 topic: 
  - image
  - basic

--- a/recipe/0009-book-1/index.md
+++ b/recipe/0009-book-1/index.md
@@ -34,7 +34,7 @@ You should also consider providing a [thumbnail][prezi3-thumbnail] for each Canv
 
 ## Example
 
-{% include manifest_links.html viewers="UV, Mirador, Annona" manifest="manifest.json" %}
+{% include manifest_links.html viewers="UV, Mirador, Annona, Clover" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" %}
 

--- a/recipe/0029-metadata-anywhere/index.md
+++ b/recipe/0029-metadata-anywhere/index.md
@@ -8,7 +8,8 @@ viewers:
  - UV
  - Mirador  
  - Annona
- - Clover
+ - id: Clover
+   support: partial
 topic: property
 property: metadata
 ---

--- a/recipe/0029-metadata-anywhere/index.md
+++ b/recipe/0029-metadata-anywhere/index.md
@@ -34,7 +34,7 @@ In this example, we have two Canvases, each with a different photograph of the s
 
 Credit: *John Dee performing an experiment before Queen Elizabeth I*. Oil painting by Henry Gillard Glindoni. Credit: Wellcome Collection. Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)
 
-{% include manifest_links.html viewers="UV, Mirador, Annona" manifest="manifest.json" %}
+{% include manifest_links.html viewers="UV, Mirador, Annona, Clover" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" config='data-line="10-59, 83-96, 136-149"' %}
 

--- a/recipe/0029-metadata-anywhere/index.md
+++ b/recipe/0029-metadata-anywhere/index.md
@@ -8,6 +8,7 @@ viewers:
  - UV
  - Mirador  
  - Annona
+ - Clover
 topic: property
 property: metadata
 ---

--- a/recipe/0029-metadata-anywhere/index.md
+++ b/recipe/0029-metadata-anywhere/index.md
@@ -5,11 +5,11 @@ layout: recipe
 tags: [presentation]
 summary: "Provide item metadata for displaying to users"
 viewers:
-  - UV
-  - Mirador
-  - Annona
-  - id: Clover
-    support: partial
+ - UV
+ - Mirador  
+ - Annona
+ - id: Clover
+   support: partial
 topic: property
 property: metadata
 ---
@@ -34,7 +34,7 @@ In this example, we have two Canvases, each with a different photograph of the s
 
 Note: Clover supports Metadata at the Manifest level but not down at the Canvas.
 
-Credit: _John Dee performing an experiment before Queen Elizabeth I_. Oil painting by Henry Gillard Glindoni. Credit: Wellcome Collection. Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)
+Credit: *John Dee performing an experiment before Queen Elizabeth I*. Oil painting by Henry Gillard Glindoni. Credit: Wellcome Collection. Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)
 
 {% include manifest_links.html viewers="UV, Mirador, Annona, Clover" manifest="manifest.json" %}
 
@@ -42,9 +42,9 @@ Credit: _John Dee performing an experiment before Queen Elizabeth I_. Oil painti
 
 # Related recipes
 
-- [Internationalization and Multi-language Values][0006]
-- [Displaying Multiple Values with Language Maps][0118]
-- [Linking to Structured Metadata][0053]
+* [Internationalization and Multi-language Values][0006]
+* [Displaying Multiple Values with Language Maps][0118]
+* [Linking to Structured Metadata][0053]
 
 {% include acronyms.md %}
 {% include links.md %}

--- a/recipe/0029-metadata-anywhere/index.md
+++ b/recipe/0029-metadata-anywhere/index.md
@@ -5,11 +5,11 @@ layout: recipe
 tags: [presentation]
 summary: "Provide item metadata for displaying to users"
 viewers:
- - UV
- - Mirador  
- - Annona
- - id: Clover
-   support: partial
+  - UV
+  - Mirador
+  - Annona
+  - id: Clover
+    support: partial
 topic: property
 property: metadata
 ---
@@ -32,7 +32,9 @@ The content of these entries is intended for presentation only; descriptive sema
 
 In this example, we have two Canvases, each with a different photograph of the same painting: one using natural light and the other an x-ray image. Metadata is provided at the Manifest level to convey information about the resource and additional metadata is provided on each Canvas to provide image-specific details.
 
-Credit: *John Dee performing an experiment before Queen Elizabeth I*. Oil painting by Henry Gillard Glindoni. Credit: Wellcome Collection. Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)
+Note: Clover supports Metadata at the Manifest level but not down at the Canvas.
+
+Credit: _John Dee performing an experiment before Queen Elizabeth I_. Oil painting by Henry Gillard Glindoni. Credit: Wellcome Collection. Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)
 
 {% include manifest_links.html viewers="UV, Mirador, Annona, Clover" manifest="manifest.json" %}
 
@@ -40,9 +42,9 @@ Credit: *John Dee performing an experiment before Queen Elizabeth I*. Oil painti
 
 # Related recipes
 
-* [Internationalization and Multi-language Values][0006]
-* [Displaying Multiple Values with Language Maps][0118]
-* [Linking to Structured Metadata][0053]
+- [Internationalization and Multi-language Values][0006]
+- [Displaying Multiple Values with Language Maps][0118]
+- [Linking to Structured Metadata][0053]
 
 {% include acronyms.md %}
 {% include links.md %}

--- a/recipe/0053-seeAlso/index.md
+++ b/recipe/0053-seeAlso/index.md
@@ -7,6 +7,7 @@ summary: "tbc"
 viewers:
  - Mirador  
  - Annona
+ - Clover
 topic: property
 property: seeAlso
 ---

--- a/recipe/0053-seeAlso/index.md
+++ b/recipe/0053-seeAlso/index.md
@@ -43,7 +43,7 @@ In this example, a MODS XML file is provided for the program as a whole, and as 
 
 To see the property in action in Mirador, toggle the sidebar by activating the three-line ("hamburger") menu in the upper left-hand corner of the content window. You should then, in the "Related" area, see the link in the "Related" section under the "See also" subheading.
 
-{% include manifest_links.html viewers="Mirador,Annona" manifest="manifest.json" %}
+{% include manifest_links.html viewers="Mirador, Annona, Clover" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" config='data-line="16-28"' %}
 

--- a/recipe/0117-add-image-thumbnail/index.md
+++ b/recipe/0117-add-image-thumbnail/index.md
@@ -6,6 +6,7 @@ tags: [image,presentation]
 summary: "Display a thumbnail image for a resource other than a Canvas, such that it can be used by clients to represent the object."
 viewers:
  - Mirador  
+ - Clover
 topic: property
 property: thumbnail
 ---

--- a/recipe/0117-add-image-thumbnail/index.md
+++ b/recipe/0117-add-image-thumbnail/index.md
@@ -31,7 +31,7 @@ None known.
 
 This example uses an image of the cover of the same kabuki performance program as in the recipe for [Viewing direction and its effect on navigation][0010]. This image, though, has a color bar and the Manifest contains an explicit `thumbnail` property for the Manifest. In this particular use case, to avoid having a thumbnail image with a color calibration bar, you can choose to declare a thumbnail from a completely different image. In Mirador, the sole viewer that uses it as of this writing, the Manifest thumbnail only displays when the site visitor uses "Add a resource" to change the loaded or active Manifests.
 
-{% include manifest_links.html viewers="Mirador" manifest="manifest.json" %}
+{% include manifest_links.html viewers="Mirador, Clover" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" %}
 

--- a/recipe/0219-using-caption-file/index.md
+++ b/recipe/0219-using-caption-file/index.md
@@ -5,6 +5,7 @@ layout: recipe
 tags: [video, caption, subtitle, presentation]
 summary: "Providing a caption or subtitle file to a video resource."
 viewers:
+ - Clover
 topic: AV
 ---
 

--- a/recipe/0219-using-caption-file/index.md
+++ b/recipe/0219-using-caption-file/index.md
@@ -34,7 +34,7 @@ When using segmented WebVTT with HLS, see [Serving HLS Files][0257].
 
 In this example we use a caption file in the WebVTT format, but other options include a subtitle file in the [SRT](https://en.wikipedia.org/wiki/SubRip) (SubRip Text) or [TTML](https://w3c.github.io/ttml3/index.html) (Timed Text Markup Language) formats, or other text-based format used for the same purpose.
 
-{% include manifest_links.html viewers="" manifest="manifest.json" %}
+{% include manifest_links.html viewers="Clover" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" config='data-line="41-67"'%}
 

--- a/recipe/matrix.md
+++ b/recipe/matrix.md
@@ -2,21 +2,22 @@
 title: Viewer Matrix
 layout: spec
 breadcrumbs:
- - label: IIIF Cookbook
-   link: index.html
+  - label: IIIF Cookbook
+    link: index.html
 viewers:
- - Mirador
- - UV
- - Annona
+  - Mirador
+  - UV
+  - Annona
+  - Clover
 topics:
- - basic
- - property
- - structure  
- - image
- - key: AV
-   note: Please note there are other IIIF AV viewers that are not listed like the [Europeana Player](https://github.com/europeana/media-player) and the [iiif-react-media-player](https://samvera-labs.github.io/iiif-react-media-player/). These are not included in the matrix due to a lack of public linkable instance rather than them not supporting some of the recipes. 
- - annotation
- - geo-recipes
+  - basic
+  - property
+  - structure
+  - image
+  - key: AV
+    note: Please note there are other IIIF AV viewers that are not listed like the [Europeana Player](https://github.com/europeana/media-player) and the [iiif-react-media-player](https://samvera-labs.github.io/iiif-react-media-player/). These are not included in the matrix due to a lack of public linkable instance rather than them not supporting some of the recipes.
+  - annotation
+  - geo-recipes
 ---
 
 <link rel='stylesheet' href="{{ site.cookbook_url | absolute_url }}/css/style.css"/>
@@ -26,27 +27,29 @@ topics:
 In the 2021 Working meeting there was a presentation on viewer support for IIIF 3.0 and the community asked if this presentation could be turned into a matrix so the community can see which viewers support which area of the IIIF specifications. This matrix is generated automatically from the recipes and if you notice any thing that is incorrect please report it to the [cookbook GitHub site](https://github.com/IIIF/cookbook-recipes/issues/new).
 
 ## Which viewers are included?
-Currently [Mirador 3](https://projectmirador.org/), the [Universal Viewer](https://universalviewer.io/) (UV) V3 and [Annona](https://ncsu-libraries.github.io/annona/multistoryboard/) are listed on the cookbook and we welcome the addition of other IIIF viewers but they must support the following features:
 
- * Support for the [IIIF version 3.0 Presentation API](https://iiif.io/api/presentation/3.0/)
- * Have a public instance available that we can link to, ideally using the `iiif-content` parameter from the [IIIF Content State API](https://iiif.io/api/content-state/)
- * Support at least 1 cookbook recipe 
+Currently [Mirador 3](https://projectmirador.org/), the [Universal Viewer](https://universalviewer.io/) (UV) V3, [Annona](https://ncsu-libraries.github.io/annona/multistoryboard/), and [Clover](https://samvera-labs.github.io/clover-iiif/) are listed on the cookbook and we welcome the addition of other IIIF viewers but they must support the following features:
+
+- Support for the [IIIF version 3.0 Presentation API](https://iiif.io/api/presentation/3.0/)
+- Have a public instance available that we can link to, ideally using the `iiif-content` parameter from the [IIIF Content State API](https://iiif.io/api/content-state/)
+- Support at least 1 cookbook recipe
 
 ## Viewer Matrix
 
 The possible values for viewer support are YES, NO or Partial. Check the recipe to see the full behaviour of the viewer to check it achieves the required function in the way you expect.
 {% for topic in page.topics  %}
-{% if topic.key %} 
-    {% assign topic_key = topic.key %}
+{% if topic.key %}
+{% assign topic_key = topic.key %}
 {% else %}
-    {% assign topic_key = topic %}
-{% endif %}   
+{% assign topic_key = topic %}
+{% endif %}
 
 ### {{ site.data.topics[topic_key].label }}
 
 {{ topic.note }}
 {% assign recipes = site.pages | where_exp: "recipe", "recipe.topic == topic_key or recipe.topic contains topic_key and recipe.id != -1" %}
 {% assign sorted = recipes | sort: "id" %}
+
 <table class="viewer">
     <tr>
         <th>Recipe</th>
@@ -81,5 +84,3 @@ The possible values for viewer support are YES, NO or Partial. Check the recipe 
 {% endfor %}
 </table>
 {% endfor %}
-
-


### PR DESCRIPTION
## Recipe Support

This PR proposes adding [Clover](https://github.com/samvera-labs/clover-iiif) to the IIIF Cookbook viewer matrix. As of now, I believe it can only be argued that Clover fully supports the following (11 distinct) recipes: 

### Basic Recipes

- 0001 Simplest Manifest - Single Image Files [View in Clover](https://samvera-labs.github.io/clover-iiif/?iiif-content=https://iiif.io/api/cookbook/recipe/0001-mvm-image/manifest.json)
- 0002 Simplest Manifest - Audio [View in Clover](https://samvera-labs.github.io/clover-iiif/?iiif-content=https://iiif.io/api/cookbook/recipe/0002-mvm-audio/manifest.json) 
- 0003 Simplest Manifest - Video [View in Clover](https://samvera-labs.github.io/clover-iiif/?iiif-content=https://iiif.io/api/cookbook/recipe/0003-mvm-video/manifest.json) 
- 0005 Support Deep Viewing with Basic Use of a IIIF Image Service [View in Clover]( https://samvera-labs.github.io/clover-iiif/?iiif-content=https://iiif.io/api/cookbook/recipe/0005-image-service/manifest.json)
- 0009 Simple Manifest - Book [View in Clover](https://samvera-labs.github.io/clover-iiif/?iiif-content=https://iiif.io/api/cookbook/recipe/0009-book-1/manifest.json ) 

### IIIF Properties
- 0007 Embedding HTML in descriptive properties [View in Clover](https://samvera-labs.github.io/clover-iiif/?iiif-content=https://iiif.io/api/cookbook/recipe/0007-string-formats/manifest.json)
- 0008 Rights statement (rights, requiredStatement) [View in Clover](https://samvera-labs.github.io/clover-iiif/?iiif-content=https://iiif.io/api/cookbook/recipe/0008-rights/)
- 0029 Metadata on any Resource (metadata) [View in Clover](https://samvera-labs.github.io/clover-iiif/?iiif-content=https://iiif.io/api/cookbook/recipe/0029-metadata-anywhere/manifest.json) **PARTIAL**
- 0053 Linking to Structured Metadata (seeAlso) [View in Clover](https://samvera-labs.github.io/clover-iiif/?iiif-content=https://iiif.io/api/cookbook/recipe/0053-seeAlso/manifest.json)
- 0117 Image Thumbnail for Manifest (thumbnail) [View in Clover](https://samvera-labs.github.io/clover-iiif/?iiif-content=https://iiif.io/api/cookbook/recipe/0117-add-image-thumbnail/manifest.json)

### Image Recipes

- 0001 Simplest Manifest - Single Image Files [View in Clover](https://samvera-labs.github.io/clover-iiif/?iiif-content=https://iiif.io/api/cookbook/recipe/0001-mvm-image/manifest.json)
- 0005 Support Deep Viewing with Basic Use of a IIIF Image Service [View in Clover]( https://samvera-labs.github.io/clover-iiif/?iiif-content=https://iiif.io/api/cookbook/recipe/0005-image-service/manifest.json)
- 0009 Simple Manifest - Book [View in Clover](https://samvera-labs.github.io/clover-iiif/?iiif-content=https://iiif.io/api/cookbook/recipe/0009-book-1/manifest.json )

### Audio/Visual Recipes

- 0002 Simplest Manifest - Audio [View in Clover](https://samvera-labs.github.io/clover-iiif/?iiif-content=https://iiif.io/api/cookbook/recipe/0002-mvm-audio/manifest.json) 
- 0003 Simplest Manifest - Video [View in Clover](https://samvera-labs.github.io/clover-iiif/?iiif-content=https://iiif.io/api/cookbook/recipe/0003-mvm-video/manifest.json) 
- 0219 Using Caption and Subtitle Files with Video Content [View in Clover](https://samvera-labs.github.io/clover-iiif/?iiif-content=https://preview.iiif.io/cookbook/clover-recipe/recipe/0219-using-caption-file/manifest.json) 