### PR TITLE
Update id values for  Displaying Multiple Values with Language Maps 0118 recipe.

### DIFF
--- a/recipe/0118_multivalue/manifest.json
+++ b/recipe/0118_multivalue/manifest.json
@@ -1,6 +1,6 @@
 {
     "@context": "http://iiif.io/api/presentation/3/context.json",
-    "id": "https://example.org/iiif/text-language/manifest",
+    "id": "https://iiif.io/api/cookbook/recipe/0118_multivalue/manifest.json",
     "type": "Manifest",
     "label": {
       "fr": [
@@ -33,17 +33,17 @@
     },
     "items": [
       {
-        "id": "https://example.org/iiif/text-language/canvas1",
+        "id": "https://iiif.io/api/cookbook/recipe/0118_multivalue/canvas1",
         "type": "Canvas",
         "width": 1114,
         "height": 991,
         "items": [
           {
-            "id": "https://example.org/iiif/text-language/canvas1/page1",
+            "id": "https://iiif.io/api/cookbook/recipe/0118_multivalue/canvas1/page1",
             "type": "AnnotationPage",
             "items": [
               {
-                "id": "https://example.org/iiif/text-language/canvas1/page1/annotation1",
+                "id": "https://iiif.io/api/cookbook/recipe/0118_multivalue/canvas1/page1/annotation1",
                 "type": "Annotation",
                 "motivation": "painting",
                 "body": {
@@ -51,7 +51,7 @@
                   "type": "Image",
                   "format": "image/jpeg"
                 },
-                "target": "https://example.org/iiif/text-language/canvas1"
+                "target": "https://iiif.io/api/cookbook/recipe/0118_multivalue/canvas1"
               }
             ]
           }

--- a/recipe/0118_multivalue/manifest.json
+++ b/recipe/0118_multivalue/manifest.json
@@ -1,6 +1,6 @@
 {
     "@context": "http://iiif.io/api/presentation/3/context.json",
-    "id": "https://iiif.io/api/cookbook/recipe/0118_multivalue/manifest.json",
+    "id": "{{ id.url }}",
     "type": "Manifest",
     "label": {
       "fr": [
@@ -33,17 +33,17 @@
     },
     "items": [
       {
-        "id": "https://iiif.io/api/cookbook/recipe/0118_multivalue/canvas1",
+        "id": "{{ id.path }}/canvas/1",
         "type": "Canvas",
         "width": 1114,
         "height": 991,
         "items": [
           {
-            "id": "https://iiif.io/api/cookbook/recipe/0118_multivalue/canvas1/page1",
+            "id": "{{ id.path }}/canvas/1/page/1",
             "type": "AnnotationPage",
             "items": [
               {
-                "id": "https://iiif.io/api/cookbook/recipe/0118_multivalue/canvas1/page1/annotation1",
+                "id": "{{ id.path }}/canvas/1/page/1/annotation/1",
                 "type": "Annotation",
                 "motivation": "painting",
                 "body": {
@@ -51,7 +51,7 @@
                   "type": "Image",
                   "format": "image/jpeg"
                 },
-                "target": "https://iiif.io/api/cookbook/recipe/0118_multivalue/canvas1"
+                "target": "{{ id.path }}/canvas/1"
               }
             ]
           }


### PR DESCRIPTION
## What does this update?

While testing for recipe support I came across an error in the [Displaying Multiple Values with Language Maps (label, summary, metadata, requiredStatement)](https://iiif.io/api/cookbook/recipe/0118_multivalue/) recipe. Functionality in Clover using `@iiif/vault` requires `id` values to match.

This updates the Manifest `id` and the referenced `id` pattern within the `items` array to use jekyll variables `{{ id.url }}` and `{{ id.path }}` respectively. These previously were pointing to *https://example.org/iiif/text-language/* . 