### PR TITLE
Recipe #0047 Linking to Web Page of an Object

### DIFF
--- a/_includes/links.md
+++ b/_includes/links.md
@@ -30,6 +30,7 @@
 
 [0040]: {{ site.cookbook_url | absolute_url }}/recipe/0040-image-rotation-service/ "Image Rotation Two Ways"
 
+[0047]: {{ site.cookbook_url | absolute_url }}/recipe/0047-homepage/ "Linking to Web Page of an Object"
 [0053]: {{ site.cookbook_url | absolute_url }}/recipe/0053-seeAlso/ "Linking to Structured Metadata"
 [0046]: {{ site.cookbook_url | absolute_url }}/recipe/0046-rendering/ "Providing Alternative Representations"
 [0064]: {{ site.cookbook_url | absolute_url }}/recipe/0064-opera-one-canvas/ "Table of Contents for Multiple A/V Files on a Single Canvas"

--- a/index.md
+++ b/index.md
@@ -115,7 +115,7 @@ _(leading on to segmentation examples later)_
 ## Linking
 
 * alternative representations (rendering (?))
-* Homepage
+* [Linking to Web Page of an Object (homepage)][0047]
 * Linking from Image API to Presentation API (via partOf as per #600, #1507)
 * Linking from Image API to external metadata
 * Linking from external metadata to Image API

--- a/recipe/0029-metadata-anywhere/index.md
+++ b/recipe/0029-metadata-anywhere/index.md
@@ -45,6 +45,7 @@ Credit: *John Dee performing an experiment before Queen Elizabeth I*. Oil painti
 * [Internationalization and Multi-language Values][0006]
 * [Displaying Multiple Values with Language Maps][0118]
 * [Linking to Structured Metadata][0053]
+- [Linking to Web Page of an Object][0047]
 
 {% include acronyms.md %}
 {% include links.md %}

--- a/recipe/0047-homepage/index.md
+++ b/recipe/0047-homepage/index.md
@@ -27,7 +27,7 @@ Entries of a `homepage` property may also have a `language` property. These valu
 
 ## Restrictions
 
-Web pages related to the Manifest that are not its home should utilize the `metadata` property as a `label` and `value` pair.
+Web pages related to the object described by the Manifest that are not its home should utilize the `metadata` property as a `label` and `value` pair.
 
 ## Example
 

--- a/recipe/0047-homepage/index.md
+++ b/recipe/0047-homepage/index.md
@@ -13,9 +13,21 @@ property: homepage
 
 ## Use Case
 
+You have a IIIF Manifest representing an object that is also represented by one or more web pages. These web pages may be published by the organization responsible for the object as well as its Manifest resource. For each homepage entry, an actionable route would be provided to a web page able to be displayed to the user.
+
 ## Implementation Notes
 
+Conforming clients may render the `homepage` property in various ways, yet most likely as an HTML Anchor element for each entry. An alternative consideration could be as a button.
+
+If an anchor is utilized for the instance, the `id` represents the destination of the link and would serve as the value for its `href` attribute.
+
+The label is rendered as the content within the link according to the [https://iiif.io/api/presentation/3.0/#language-of-property-values](Language of Property Values). A client may also choose to provide a `lang` attribute on the anchor element with a value of the determined BCP 47 language code of the `label`.
+
+Entries of a homepage property may also have a `language` property. These values represent the language(s) of the destination web page. A client may also render a single language entry as the value for `hreflang` attribute on the anchor element.
+
 ## Restrictions
+
+Web pages related to the Manifest that are not its home should utilize the metadata property as a label and value pair.
 
 ## Example
 

--- a/recipe/0047-homepage/index.md
+++ b/recipe/0047-homepage/index.md
@@ -1,0 +1,25 @@
+---
+title: Linking to Web Page for Object
+id: 47
+layout: recipe
+tags: [metadata,presentation]
+summary: "tbc"
+viewers:
+ - Mirador
+topic: property
+property: homepage
+---
+
+## Use Case
+
+## Implementation Notes
+
+## Restrictions
+
+## Example
+
+## Related Recipes
+
+{% include acronyms.md %}
+{% include links.md %}
+

--- a/recipe/0047-homepage/index.md
+++ b/recipe/0047-homepage/index.md
@@ -17,7 +17,7 @@ You have a IIIF Manifest representing an object that is also represented by one 
 
 ## Implementation Notes
 
-Conforming clients may render the `homepage` property in various ways, yet most likely as an HTML Anchor element for each entry. An alternative consideration could be as a button.
+Conforming clients may render the `homepage` property in various ways, yet most likely as an HTML anchor element for each entry. An alternative consideration could be as a button.
 
 If an anchor is utilized for the instance, the `id` represents the destination of the link and would serve as the value for its `href` attribute.
 
@@ -31,9 +31,13 @@ Web pages related to the Manifest that are not its home should utilize the `meta
 
 ## Example
 
+In this example we have a Manifest representing an object housed at the Yale Center for British Art. A `homepage` property is at the Manifest level with one entry. The single instance references the URL at which a user could be displayed a web page of the object’s catalog entry.
+
+_Greenland Falcon._ Beeswax on panel by George Stubbs. Credit: Yale Center for British Art, Paul Mellon Collection. Public Domain Dedication (CC0 1.0 Universal)
+
 {% include manifest_links.html viewers="Mirador, Clover" manifest="manifest.json" %}
 
-{% include jsonviewer.html src="manifest.json" config='data-line="26-36"' %}
+{% include jsonviewer.html src="manifest.json" config='data-line="42-52"' %}
 
 ## Related Recipes
 

--- a/recipe/0047-homepage/index.md
+++ b/recipe/0047-homepage/index.md
@@ -27,7 +27,7 @@ Entries of a homepage property may also have a `language` property. These values
 
 ## Restrictions
 
-Web pages related to the Manifest that are not its home should utilize the `metadata property` as a `label` and `value` pair.
+Web pages related to the Manifest that are not its home should utilize the `metadata` property as a `label` and `value` pair.
 
 ## Example
 

--- a/recipe/0047-homepage/index.md
+++ b/recipe/0047-homepage/index.md
@@ -41,5 +41,8 @@ _Greenland Falcon._ Beeswax on panel by George Stubbs. Credit: Yale Center for B
 
 ## Related Recipes
 
+* [Acknowledge Content Contributors][0234] for demonstrating the use of `homepage` for a `provider`
+* [Linking to Structured Metadata][0053] for demonstrating the use of `seeAlso`
+
 {% include acronyms.md %}
 {% include links.md %}

--- a/recipe/0047-homepage/index.md
+++ b/recipe/0047-homepage/index.md
@@ -23,11 +23,11 @@ If an anchor is utilized for the instance, the `id` represents the destination o
 
 The label is rendered as the content within the link according to the [Language of Property Values](https://iiif.io/api/presentation/3.0/#language-of-property-values). A client may also choose to provide a `lang` attribute on the anchor element with a value of the determined BCP 47 language code of the `label`.
 
-Entries of a homepage property may also have a `language` property. These values represent the language(s) of the destination web page. A client may also render a single language entry as the value for `hreflang` attribute on the anchor element.
+Entries of a homepage property may also have a `language` property. These values represent the language(s) of the destination web page. A client may also render a _single_ language entry as the value for `hreflang` attribute on the anchor element.
 
 ## Restrictions
 
-Web pages related to the Manifest that are not its home should utilize the metadata property as a label and value pair.
+Web pages related to the Manifest that are not its home should utilize the `metadata property` as a `label` and `value` pair.
 
 ## Example
 

--- a/recipe/0047-homepage/index.md
+++ b/recipe/0047-homepage/index.md
@@ -2,10 +2,11 @@
 title: Linking to Web Page for Object
 id: 47
 layout: recipe
-tags: [metadata,presentation]
+tags: [metadata, presentation]
 summary: "tbc"
 viewers:
- - Mirador
+  - Mirador
+  - Clover
 topic: property
 property: homepage
 ---
@@ -18,8 +19,11 @@ property: homepage
 
 ## Example
 
+{% include manifest_links.html viewers="Mirador, Clover" manifest="manifest.json" %}
+
+{% include jsonviewer.html src="manifest.json" config='data-line="26-36"' %}
+
 ## Related Recipes
 
 {% include acronyms.md %}
 {% include links.md %}
-

--- a/recipe/0047-homepage/index.md
+++ b/recipe/0047-homepage/index.md
@@ -43,6 +43,7 @@ _Laocöon_. Credit: Getty.
 
 - [Acknowledge Content Contributors][0234] for demonstrating the use of `homepage` for a `provider`
 - [Linking to Structured Metadata][0053] for demonstrating the use of `seeAlso`
+- [Metadata on any Resource][0029]
 
 {% include acronyms.md %}
 {% include links.md %}

--- a/recipe/0047-homepage/index.md
+++ b/recipe/0047-homepage/index.md
@@ -37,7 +37,7 @@ _Greenland Falcon._ Beeswax on panel by George Stubbs. Credit: Yale Center for B
 
 {% include manifest_links.html viewers="Mirador, Clover" manifest="manifest.json" %}
 
-{% include jsonviewer.html src="manifest.json" config='data-line="42-52"' %}
+{% include jsonviewer.html src="manifest.json" config='data-line="60-74"' %}
 
 ## Related Recipes
 

--- a/recipe/0047-homepage/index.md
+++ b/recipe/0047-homepage/index.md
@@ -23,7 +23,7 @@ If an anchor is utilized for the instance, the `id` represents the destination o
 
 The `label` is rendered as the content within the link according to the [Language of Property Values](https://iiif.io/api/presentation/3.0/#language-of-property-values). A client may also choose to provide a `lang` attribute on the anchor element with a value of the determined BCP 47 language code of the `label`.
 
-Entries of a `homepage` property may also have a `language` property. These values represent the language(s) of the destination web page. A client may also render a _single_ language entry as the value for `hreflang` attribute on the anchor element.
+Entries of a `homepage` property may also have a `language` property. These values represent the language(s) of the destination web page. A client may also render a _single_ language entry as the value for `hreflang` attribute on the anchor element. Entries should have a `format` property, most likely with a value being `text/html`.
 
 ## Restrictions
 

--- a/recipe/0047-homepage/index.md
+++ b/recipe/0047-homepage/index.md
@@ -13,7 +13,7 @@ property: homepage
 
 ## Use Case
 
-You have a IIIF Manifest representing an object that is also represented by one or more web pages. These web pages may be published by the organization responsible for the object as well as its Manifest resource. For each homepage entry, an actionable route would be provided to a web page able to be displayed to the user.
+You have a IIIF Manifest representing an object that is also represented by one or more home pages by an organization. These web pages may be published by the organization responsible for the object as well as its Manifest resource. For each homepage entry, an actionable route would be provided to a web page able to be displayed to the user.
 
 ## Implementation Notes
 

--- a/recipe/0047-homepage/index.md
+++ b/recipe/0047-homepage/index.md
@@ -1,5 +1,5 @@
 ---
-title: Linking to Web Page for Object
+title: Linking to Web Page of an Object
 id: 47
 layout: recipe
 tags: [metadata, presentation]
@@ -21,7 +21,7 @@ Conforming clients may render the `homepage` property in various ways, yet most 
 
 If an anchor is utilized for the instance, the `id` represents the destination of the link and would serve as the value for its `href` attribute.
 
-The label is rendered as the content within the link according to the [https://iiif.io/api/presentation/3.0/#language-of-property-values](Language of Property Values). A client may also choose to provide a `lang` attribute on the anchor element with a value of the determined BCP 47 language code of the `label`.
+The label is rendered as the content within the link according to the [Language of Property Values](https://iiif.io/api/presentation/3.0/#language-of-property-values). A client may also choose to provide a `lang` attribute on the anchor element with a value of the determined BCP 47 language code of the `label`.
 
 Entries of a homepage property may also have a `language` property. These values represent the language(s) of the destination web page. A client may also render a single language entry as the value for `hreflang` attribute on the anchor element.
 

--- a/recipe/0047-homepage/index.md
+++ b/recipe/0047-homepage/index.md
@@ -31,13 +31,13 @@ Web pages related to the Manifest that are not its home should utilize the `meta
 
 ## Example
 
-In this example we have a Manifest representing an object housed at the Yale Center for British Art. A `homepage` property is at the Manifest level with one entry. The single instance references the URL at which a user could be displayed a web page of the object’s catalog entry.
+In this example we have a Manifest representing an object housed at the Getty Museum Collection. A `homepage` property is at the Manifest level with one entry. The single instance references the URL at which a user could be displayed a web page of the object’s catalog entry.
 
-_Greenland Falcon._ Beeswax on panel by George Stubbs. Credit: Yale Center for British Art, Paul Mellon Collection.
+_Laocöon_. Credit: Getty.
 
 {% include manifest_links.html viewers="Mirador, Clover" manifest="manifest.json" %}
 
-{% include jsonviewer.html src="manifest.json" config='data-line="10-14"' %}
+{% include jsonviewer.html src="manifest.json" config='data-line="10-24"' %}
 
 ## Related Recipes
 

--- a/recipe/0047-homepage/index.md
+++ b/recipe/0047-homepage/index.md
@@ -21,9 +21,9 @@ Conforming clients may render the `homepage` property in various ways, yet most 
 
 If an anchor is utilized for the instance, the `id` represents the destination of the link and would serve as the value for its `href` attribute.
 
-The label is rendered as the content within the link according to the [Language of Property Values](https://iiif.io/api/presentation/3.0/#language-of-property-values). A client may also choose to provide a `lang` attribute on the anchor element with a value of the determined BCP 47 language code of the `label`.
+The `label` is rendered as the content within the link according to the [Language of Property Values](https://iiif.io/api/presentation/3.0/#language-of-property-values). A client may also choose to provide a `lang` attribute on the anchor element with a value of the determined BCP 47 language code of the `label`.
 
-Entries of a homepage property may also have a `language` property. These values represent the language(s) of the destination web page. A client may also render a _single_ language entry as the value for `hreflang` attribute on the anchor element.
+Entries of a `homepage` property may also have a `language` property. These values represent the language(s) of the destination web page. A client may also render a _single_ language entry as the value for `hreflang` attribute on the anchor element.
 
 ## Restrictions
 
@@ -33,16 +33,16 @@ Web pages related to the Manifest that are not its home should utilize the `meta
 
 In this example we have a Manifest representing an object housed at the Yale Center for British Art. A `homepage` property is at the Manifest level with one entry. The single instance references the URL at which a user could be displayed a web page of the object’s catalog entry.
 
-_Greenland Falcon._ Beeswax on panel by George Stubbs. Credit: Yale Center for British Art, Paul Mellon Collection. Public Domain Dedication (CC0 1.0 Universal)
+_Greenland Falcon._ Beeswax on panel by George Stubbs. Credit: Yale Center for British Art, Paul Mellon Collection.
 
 {% include manifest_links.html viewers="Mirador, Clover" manifest="manifest.json" %}
 
-{% include jsonviewer.html src="manifest.json" config='data-line="60-74"' %}
+{% include jsonviewer.html src="manifest.json" config='data-line="10-14"' %}
 
 ## Related Recipes
 
-* [Acknowledge Content Contributors][0234] for demonstrating the use of `homepage` for a `provider`
-* [Linking to Structured Metadata][0053] for demonstrating the use of `seeAlso`
+- [Acknowledge Content Contributors][0234] for demonstrating the use of `homepage` for a `provider`
+- [Linking to Structured Metadata][0053] for demonstrating the use of `seeAlso`
 
 {% include acronyms.md %}
 {% include links.md %}

--- a/recipe/0047-homepage/manifest.json
+++ b/recipe/0047-homepage/manifest.json
@@ -8,10 +8,26 @@
   "metadata": [
     {
       "label": {
+        "en": ["Title"]
+      },
+      "value": {
+        "en": ["Greenland Falcon"]
+      }
+    },
+    {
+      "label": {
         "en": ["Medium"]
       },
       "value": {
         "en": ["beeswax on panel"]
+      }
+    },
+    {
+      "label": {
+        "en": ["Credit Line"]
+      },
+      "value": {
+        "en": ["Yale Center for British Art, Paul Mellon Collection"]
       }
     },
     {
@@ -34,6 +50,17 @@
       "language": ["en"]
     }
   ],
+  "rights": "https://creativecommons.org/publicdomain/zero/1.0/",
+  "requiredStatement": {
+    "label": {
+      "en": ["Rights Description"]
+    },
+    "value": {
+      "en": [
+        "Metadata describing Yale Center for British Art collections is public domain under CC0. Copyright or other restrictions may apply to cultural works or images of those works in this record."
+      ]
+    }
+  },
   "items": [
     {
       "id": "{{ id.path }}/canvas/1",
@@ -80,110 +107,6 @@
           "service": [
             {
               "@id": "https://media.collections.yale.edu/thumbnail/ycba/a1333c03-be5b-4f5b-a897-7e15e3d17b29",
-              "@type": "ImageService2",
-              "profile": "level0"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "{{ id.path }}/canvas/2",
-      "type": "Canvas",
-      "label": {
-        "en": ["recto, framed"]
-      },
-      "height": 4446,
-      "width": 4512,
-      "items": [
-        {
-          "id": "{{ id.path }}/canvas/2/page/1",
-          "type": "AnnotationPage",
-          "items": [
-            {
-              "id": "{{ id.path }}/canvas/2/page/1/annotation/1",
-              "type": "Annotation",
-              "motivation": "painting",
-              "body": {
-                "id": "https://images.collections.yale.edu/iiif/2/ycba:3f8bfa84-0b32-4f19-8b7e-44f4a3b221d0/full/full/0/default.jpg",
-                "type": "Image",
-                "format": "image/jpeg",
-                "service": [
-                  {
-                    "@id": "https://images.collections.yale.edu/iiif/2/ycba:3f8bfa84-0b32-4f19-8b7e-44f4a3b221d0",
-                    "@type": "ImageService2",
-                    "profile": "http://iiif.io/api/image/2/level2.json"
-                  }
-                ],
-                "height": 4446,
-                "width": 4512
-              },
-              "target": "{{ id.path }}/canvas/2"
-            }
-          ]
-        }
-      ],
-      "thumbnail": [
-        {
-          "id": "https://media.collections.yale.edu/thumbnail/ycba/3f8bfa84-0b32-4f19-8b7e-44f4a3b221d0",
-          "type": "Image",
-          "width": 480,
-          "height": 473,
-          "service": [
-            {
-              "@id": "https://media.collections.yale.edu/thumbnail/ycba/3f8bfa84-0b32-4f19-8b7e-44f4a3b221d0",
-              "@type": "ImageService2",
-              "profile": "level0"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "{{ id.path }}/canvas/3",
-      "type": "Canvas",
-      "label": {
-        "en": ["x-radiograph"]
-      },
-      "height": 17753,
-      "width": 21262,
-      "items": [
-        {
-          "id": "{{ id.path }}/canvas/3/page/1",
-          "type": "AnnotationPage",
-          "items": [
-            {
-              "id": "{{ id.path }}/canvas/3/page/1/annotation/1",
-              "type": "Annotation",
-              "motivation": "painting",
-              "body": {
-                "id": "https://images.collections.yale.edu/iiif/2/ycba:d7e1622d-adfa-4c32-9077-c8c969e72b9a/full/full/0/default.jpg",
-                "type": "Image",
-                "format": "image/jpeg",
-                "service": [
-                  {
-                    "@id": "https://images.collections.yale.edu/iiif/2/ycba:d7e1622d-adfa-4c32-9077-c8c969e72b9a",
-                    "@type": "ImageService2",
-                    "profile": "http://iiif.io/api/image/2/level2.json"
-                  }
-                ],
-                "height": 17753,
-                "width": 21262
-              },
-              "target": "{{ id.path }}/canvas/3"
-            }
-          ]
-        }
-      ],
-      "thumbnail": [
-        {
-          "id": "https://media.collections.yale.edu/thumbnail/ycba/d7e1622d-adfa-4c32-9077-c8c969e72b9a",
-          "type": "Image",
-          "width": 480,
-          "height": 401,
-          "service": [
-            {
-              "@id": "https://media.collections.yale.edu/thumbnail/ycba/d7e1622d-adfa-4c32-9077-c8c969e72b9a",
               "@type": "ImageService2",
               "profile": "level0"
             }

--- a/recipe/0047-homepage/manifest.json
+++ b/recipe/0047-homepage/manifest.json
@@ -5,40 +5,6 @@
   "label": {
     "en": ["George Stubbs, 1724–1806, British, Greenland Falcon, 1780"]
   },
-  "metadata": [
-    {
-      "label": {
-        "en": ["Title"]
-      },
-      "value": {
-        "en": ["Greenland Falcon"]
-      }
-    },
-    {
-      "label": {
-        "en": ["Medium"]
-      },
-      "value": {
-        "en": ["beeswax on panel"]
-      }
-    },
-    {
-      "label": {
-        "en": ["Credit Line"]
-      },
-      "value": {
-        "en": ["Yale Center for British Art, Paul Mellon Collection"]
-      }
-    },
-    {
-      "label": {
-        "en": ["Institution"]
-      },
-      "value": {
-        "en": ["Yale Center for British Art"]
-      }
-    }
-  ],
   "homepage": [
     {
       "id": "https://collections.britishart.yale.edu/catalog/tms:21168",
@@ -50,16 +16,6 @@
       "language": ["en"]
     }
   ],
-  "requiredStatement": {
-    "label": {
-      "en": ["Rights Description"]
-    },
-    "value": {
-      "en": [
-        "Metadata describing Yale Center for British Art collections is public domain under CC0. Copyright or other restrictions may apply to cultural works or images of those works in this record."
-      ]
-    }
-  },
   "items": [
     {
       "id": "{{ id.path }}/canvas/1",

--- a/recipe/0047-homepage/manifest.json
+++ b/recipe/0047-homepage/manifest.json
@@ -21,7 +21,7 @@
       "id": "{{ id.path }}/canvas/1",
       "type": "Canvas",
       "label": {
-        "none": ["Laocöon"]
+        "none": ["Front"]
       },
       "height": 3000,
       "width": 2315,

--- a/recipe/0047-homepage/manifest.json
+++ b/recipe/0047-homepage/manifest.json
@@ -50,7 +50,6 @@
       "language": ["en"]
     }
   ],
-  "rights": "https://creativecommons.org/publicdomain/zero/1.0/",
   "requiredStatement": {
     "label": {
       "en": ["Rights Description"]

--- a/recipe/0047-homepage/manifest.json
+++ b/recipe/0047-homepage/manifest.json
@@ -3,14 +3,14 @@
   "id": "{{ id.url }}",
   "type": "Manifest",
   "label": {
-    "en": ["George Stubbs, 1724–1806, British, Greenland Falcon, 1780"]
+    "none": ["Laocöon"]
   },
   "homepage": [
     {
-      "id": "https://collections.britishart.yale.edu/catalog/tms:21168",
+      "id": "https://www.getty.edu/art/collection/object/103RQQ",
       "type": "Text",
       "label": {
-        "en": ["Catalog entry at the Yale Center for British Art"]
+        "en": ["Home page at the Getty Museum Collection"]
       },
       "format": "text/html",
       "language": ["en"]
@@ -21,10 +21,10 @@
       "id": "{{ id.path }}/canvas/1",
       "type": "Canvas",
       "label": {
-        "en": ["recto, cropped to image"]
+        "none": ["Laocöon"]
       },
-      "height": 3087,
-      "width": 3786,
+      "height": 3000,
+      "width": 2315,
       "items": [
         {
           "id": "{{ id.path }}/canvas/1/page/1",
@@ -35,35 +35,20 @@
               "type": "Annotation",
               "motivation": "painting",
               "body": {
-                "id": "https://images.collections.yale.edu/iiif/2/ycba:a1333c03-be5b-4f5b-a897-7e15e3d17b29/full/full/0/default.jpg",
+                "id": "https://iiif.io/api/image/3.0/example/reference/28473c77da3deebe4375c3a50572d9d3-laocoon/full/!500,500/0/default.jpg",
                 "type": "Image",
                 "format": "image/jpeg",
                 "service": [
                   {
-                    "@id": "https://images.collections.yale.edu/iiif/2/ycba:a1333c03-be5b-4f5b-a897-7e15e3d17b29",
-                    "@type": "ImageService2",
-                    "profile": "http://iiif.io/api/image/2/level2.json"
+                    "@id": "https://iiif.io/api/image/3.0/example/reference/28473c77da3deebe4375c3a50572d9d3-laocoon",
+                    "@type": "ImageService3",
+                    "profile": "http://iiif.io/api/image/2/level1.json"
                   }
                 ],
-                "height": 3087,
-                "width": 3786
+                "height": 3000,
+                "width": 2315
               },
               "target": "{{ id.path }}/canvas/1"
-            }
-          ]
-        }
-      ],
-      "thumbnail": [
-        {
-          "id": "https://media.collections.yale.edu/thumbnail/ycba/a1333c03-be5b-4f5b-a897-7e15e3d17b29",
-          "type": "Image",
-          "width": 480,
-          "height": 391,
-          "service": [
-            {
-              "@id": "https://media.collections.yale.edu/thumbnail/ycba/a1333c03-be5b-4f5b-a897-7e15e3d17b29",
-              "@type": "ImageService2",
-              "profile": "level0"
             }
           ]
         }

--- a/recipe/0047-homepage/manifest.json
+++ b/recipe/0047-homepage/manifest.json
@@ -3,33 +3,23 @@
   "id": "{{ id.url }}",
   "type": "Manifest",
   "label": {
-    "en": [
-      "George Stubbs, 1724–1806, British, Greenland Falcon, 1780"
-    ]
+    "en": ["George Stubbs, 1724–1806, British, Greenland Falcon, 1780"]
   },
   "metadata": [
     {
       "label": {
-        "en": [
-          "Medium"
-        ]
+        "en": ["Medium"]
       },
       "value": {
-        "en": [
-          "beeswax on panel"
-        ]
+        "en": ["beeswax on panel"]
       }
     },
     {
       "label": {
-        "en": [
-          "Institution"
-        ]
+        "en": ["Institution"]
       },
       "value": {
-        "en": [
-          "Yale Center for British Art"
-        ]
+        "en": ["Yale Center for British Art"]
       }
     }
   ],
@@ -38,12 +28,10 @@
       "id": "https://collections.britishart.yale.edu/catalog/tms:21168",
       "type": "Text",
       "label": {
-        "en": [
-          "Catalog entry at the Yale Center for British Art"
-        ]
+        "en": ["Catalog entry at the Yale Center for British Art"]
       },
       "format": "text/html",
-      "language": [ "en" ]
+      "language": ["en"]
     }
   ],
   "items": [
@@ -51,9 +39,7 @@
       "id": "{{ id.path }}/canvas/1",
       "type": "Canvas",
       "label": {
-        "en": [
-          "recto, cropped to image"
-        ]
+        "en": ["recto, cropped to image"]
       },
       "height": 3087,
       "width": 3786,
@@ -105,9 +91,7 @@
       "id": "{{ id.path }}/canvas/2",
       "type": "Canvas",
       "label": {
-        "en": [
-          "recto, framed"
-        ]
+        "en": ["recto, framed"]
       },
       "height": 4446,
       "width": 4512,
@@ -159,9 +143,7 @@
       "id": "{{ id.path }}/canvas/3",
       "type": "Canvas",
       "label": {
-        "en": [
-          "x-radiograph"
-        ]
+        "en": ["x-radiograph"]
       },
       "height": 17753,
       "width": 21262,

--- a/recipe/0047-homepage/manifest.json
+++ b/recipe/0047-homepage/manifest.json
@@ -1,0 +1,213 @@
+{
+  "@context": "http://iiif.io/api/presentation/3/context.json",
+  "id": "{{ id.url }}",
+  "type": "Manifest",
+  "label": {
+    "en": [
+      "George Stubbs, 1724–1806, British, Greenland Falcon, 1780"
+    ]
+  },
+  "metadata": [
+    {
+      "label": {
+        "en": [
+          "Medium"
+        ]
+      },
+      "value": {
+        "en": [
+          "beeswax on panel"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Institution"
+        ]
+      },
+      "value": {
+        "en": [
+          "Yale Center for British Art"
+        ]
+      }
+    }
+  ],
+  "homepage": [
+    {
+      "id": "https://collections.britishart.yale.edu/catalog/tms:21168",
+      "type": "Text",
+      "label": {
+        "en": [
+          "Catalog entry at the Yale Center for British Art"
+        ]
+      },
+      "format": "text/html",
+      "language": [ "en" ]
+    }
+  ],
+  "items": [
+    {
+      "id": "{{ id.path }}/canvas/1",
+      "type": "Canvas",
+      "label": {
+        "en": [
+          "recto, cropped to image"
+        ]
+      },
+      "height": 3087,
+      "width": 3786,
+      "items": [
+        {
+          "id": "{{ id.path }}/canvas/1/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "{{ id.path }}/canvas/1/page/1/annotation/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://images.collections.yale.edu/iiif/2/ycba:a1333c03-be5b-4f5b-a897-7e15e3d17b29/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "service": [
+                  {
+                    "@id": "https://images.collections.yale.edu/iiif/2/ycba:a1333c03-be5b-4f5b-a897-7e15e3d17b29",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ],
+                "height": 3087,
+                "width": 3786
+              },
+              "target": "{{ id.path }}/canvas/1"
+            }
+          ]
+        }
+      ],
+      "thumbnail": [
+        {
+          "id": "https://media.collections.yale.edu/thumbnail/ycba/a1333c03-be5b-4f5b-a897-7e15e3d17b29",
+          "type": "Image",
+          "width": 480,
+          "height": 391,
+          "service": [
+            {
+              "@id": "https://media.collections.yale.edu/thumbnail/ycba/a1333c03-be5b-4f5b-a897-7e15e3d17b29",
+              "@type": "ImageService2",
+              "profile": "level0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "{{ id.path }}/canvas/2",
+      "type": "Canvas",
+      "label": {
+        "en": [
+          "recto, framed"
+        ]
+      },
+      "height": 4446,
+      "width": 4512,
+      "items": [
+        {
+          "id": "{{ id.path }}/canvas/2/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "{{ id.path }}/canvas/2/page/1/annotation/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://images.collections.yale.edu/iiif/2/ycba:3f8bfa84-0b32-4f19-8b7e-44f4a3b221d0/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "service": [
+                  {
+                    "@id": "https://images.collections.yale.edu/iiif/2/ycba:3f8bfa84-0b32-4f19-8b7e-44f4a3b221d0",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ],
+                "height": 4446,
+                "width": 4512
+              },
+              "target": "{{ id.path }}/canvas/2"
+            }
+          ]
+        }
+      ],
+      "thumbnail": [
+        {
+          "id": "https://media.collections.yale.edu/thumbnail/ycba/3f8bfa84-0b32-4f19-8b7e-44f4a3b221d0",
+          "type": "Image",
+          "width": 480,
+          "height": 473,
+          "service": [
+            {
+              "@id": "https://media.collections.yale.edu/thumbnail/ycba/3f8bfa84-0b32-4f19-8b7e-44f4a3b221d0",
+              "@type": "ImageService2",
+              "profile": "level0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "{{ id.path }}/canvas/3",
+      "type": "Canvas",
+      "label": {
+        "en": [
+          "x-radiograph"
+        ]
+      },
+      "height": 17753,
+      "width": 21262,
+      "items": [
+        {
+          "id": "{{ id.path }}/canvas/3/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "{{ id.path }}/canvas/3/page/1/annotation/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://images.collections.yale.edu/iiif/2/ycba:d7e1622d-adfa-4c32-9077-c8c969e72b9a/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "service": [
+                  {
+                    "@id": "https://images.collections.yale.edu/iiif/2/ycba:d7e1622d-adfa-4c32-9077-c8c969e72b9a",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ],
+                "height": 17753,
+                "width": 21262
+              },
+              "target": "{{ id.path }}/canvas/3"
+            }
+          ]
+        }
+      ],
+      "thumbnail": [
+        {
+          "id": "https://media.collections.yale.edu/thumbnail/ycba/d7e1622d-adfa-4c32-9077-c8c969e72b9a",
+          "type": "Image",
+          "width": 480,
+          "height": 401,
+          "service": [
+            {
+              "@id": "https://media.collections.yale.edu/thumbnail/ycba/d7e1622d-adfa-4c32-9077-c8c969e72b9a",
+              "@type": "ImageService2",
+              "profile": "level0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/recipe/0234-provider/index.md
+++ b/recipe/0234-provider/index.md
@@ -42,7 +42,7 @@ Only Mirador implements `provider`, and only partially. The property must be on 
 
 ## Related Recipes
 
-* [homepage][0047] for demonstrating the use of `homepage`
+* [Linking to Web Page of an Object][0047] for demonstrating the use of `homepage` at the Manifest level
 * [Add Identifying Graphic][0217] for demonstrating the use of `logo`
 * [Linking to Structured Metadata][0053] for demonstrating the use of `seeAlso`
 * [Rights][0008] for demonstrating use of `requiredStatement`


### PR DESCRIPTION
This PR addresses https://github.com/IIIF/cookbook-recipes/issues/47, setting the `homepage` property of a IIIF Manifest.