### PR TITLE
Update Ramp site URL, add Ramp to recipe-0013

### DIFF
--- a/_includes/viewer_link.html
+++ b/_includes/viewer_link.html
@@ -48,7 +48,7 @@
     {% assign default_text="View in Navplace Viewer" %}
 {% elsif include.type == 'Ramp' %}
     {% capture viewer_url %}
-        https://iiif-react-media-player.netlify.app//?iiif-content={{manifest_url |strip}}
+    https://ramp.avalonmediasystem.org/?iiif-content={{manifest_url |strip}}
     {% endcapture %}
     {% assign default_text="View in Ramp" %}
 {% else %}    

--- a/recipe/0013-placeholderCanvas/index.md
+++ b/recipe/0013-placeholderCanvas/index.md
@@ -5,6 +5,7 @@ layout: recipe
 tags: video, audio, image, av
 summary: "Provide the user with something to look at before they choose to start interacting with the main content, and/or while they wait for it to load/buffer."
 viewers:
+ - Ramp
 topic: 
  - property
  - AV
@@ -34,7 +35,7 @@ In the example, the main content is a video of a performance of Donizetti's _L'e
 
 _Note: The `placeholderCanvas` property is not yet supported in viewers._
 
-{% include manifest_links.html viewers="" manifest="manifest.json" %}
+{% include manifest_links.html viewers="Ramp" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" config="data-line='17-43'"%}
 


### PR DESCRIPTION
This PR contains the following changes:
- Update link to the Ramp demo site to https://ramp.avalonmediasystem.org. The old site at the URL: https://iiif-react-media-player.netlify.app/ is still functional, but we plan to use the new URL going forward. Both these sites are up-to-date with latest changes in the code.
- Add Ramp to [Load a Preview Image Before the Main Content](https://iiif.io/api/cookbook/recipe/0013-placeholderCanvas/) recipe