### PR TITLE
Update Clover IIIF `Viewer` url.

### DIFF
--- a/_includes/viewer_link.html
+++ b/_includes/viewer_link.html
@@ -38,7 +38,7 @@
     {% assign default_text="View in Annona" %}
 {% elsif include.type == 'Clover' %}
     {% capture viewer_url %}
-        https://samvera-labs.github.io/clover-iiif/?iiif-content={{manifest_url |strip}}
+        https://samvera-labs.github.io/clover-iiif/docs/viewer/demo?iiif-content={{manifest_url |strip}}
     {% endcapture %}
     {% assign default_text="View in Clover" %}
 {% elsif include.type == 'Navplace Viewer' %}


### PR DESCRIPTION
## What does this do?

Clover now encapsulates multiple components and this updates the Clover IIIF `Viewer` URL to its new locations in Clover's docs.