### PR TITLE
Add text noting support for `logo` to #234, `provider` recipe

### DIFF
--- a/recipe/0234-provider/index.md
+++ b/recipe/0234-provider/index.md
@@ -34,7 +34,7 @@ None known.
 
 In this example, we reuse the front page of a kabuki playbill that was contributed to the IIIF Cookbook by UCLA Library Digital Collections. The `id` for them as an Agent is the US Library of Congress authority ID for the UCLA Library, the `homepage` is their actual homepage, the `logo` is also for the library as a whole, and the `seeAlso` is the US Library of Congress MADS/XML. In your use of this property, you might want to and be able to unify the information in the property differently.
 
-Only Mirador implements `provider`, and only partially. The property must be on the Manifest level, Mirador will only display the text from a `label` under `provider`, and the information will only be found in the list of manifests.
+Only Mirador implements `provider`, and only partially. The property must be on the Manifest level, Mirador will only display the text from a `label` and the image from a  `logo` under `provider`, and the information will only be found in the list of manifests.
 
 {% include manifest_links.html viewers="Mirador" manifest="manifest.json" %}
 


### PR DESCRIPTION
Mirador still only partially supports `provider`, but it supports it a little more than before
