### PR TITLE
Add text about `duration` value datatype in #2 and #3

### DIFF
--- a/recipe/0002-mvm-audio/index.md
+++ b/recipe/0002-mvm-audio/index.md
@@ -23,7 +23,7 @@ The simplest viable manifest for audio content. This pattern presents a single a
 
 ## Implementation Notes
 
-The implementation is identical to the [image example][0001], except that the content is audio and the canvas has the `duration` property instead of the `height` and `width` properties.
+The implementation is identical to the [image example][0001], except that the content is audio and the canvas has the `duration` property instead of the `height` and `width` properties. The value of the `duration` property [must be a floating point number](https://iiif.io/api/presentation/3.0/#duration). If the duration value you have is an integer, it therefore needs to be written with at least a decimal point and a trailing zero: `1985.0` rather than `1985`.
 
 ## Example
 

--- a/recipe/0003-mvm-video/index.md
+++ b/recipe/0003-mvm-video/index.md
@@ -23,7 +23,7 @@ The simplest viable manifest for video content. This pattern presents a single v
 
 ## Implementation Notes
 
-The implementation is identical to the [image example][0001], except that the content is video and the canvas has a duration as well as a height and width.
+The implementation is identical to the [image example][0001], except that the content is video and the canvas has the `duration` property instead of the `height` and `width` properties. The value of the `duration` property [must be a floating point number](https://iiif.io/api/presentation/3.0/#duration). If the duration value you have is an integer, it therefore needs to be written with at least a decimal point and a trailing zero: `1985.0` rather than `1985`.
 
 ## Example
 


### PR DESCRIPTION
The value for a `duration` property must be a floating point number (per Prezi 3.0 API), and these recipes are the proper places to note that.
