### PR TITLE
Add Glycerine Viewer

### DIFF
--- a/_includes/viewer_link.html
+++ b/_includes/viewer_link.html
@@ -46,6 +46,11 @@
     https://ramp.avalonmediasystem.org/?iiif-content={{manifest_url |strip}}
     {% endcapture %}
     {% assign default_text="View in Ramp" %}
+{% elsif include.type == 'Glycerine Viewer' %}
+    {% capture viewer_url %}
+    https://demo.viewer.glycerine.io/viewer?iiif-content={{manifest_url |strip}}
+    {% endcapture %}
+    {% assign default_text="View in Glycerine Viewer" %}
 {% else %}    
     {% capture default_text %}Unknown Viewer type '{{ include.type}}'{% endcapture %}
     {% capture viewer_url %}{{manifest_url |strip}}{% endcapture %}

--- a/recipe/0001-mvm-image/index.md
+++ b/recipe/0001-mvm-image/index.md
@@ -9,6 +9,7 @@ viewers:
  - UV
  - Annona
  - Clover
+ - Glycerine Viewer
 topic: 
  - basic
  - image

--- a/recipe/0005-image-service/index.md
+++ b/recipe/0005-image-service/index.md
@@ -8,6 +8,7 @@ viewers:
  - Mirador
  - Annona
  - Clover
+ - Glycerine Viewer
 topic: 
  - basic 
  - image
@@ -35,7 +36,7 @@ Though a version 3 Manifest may specify a service using the version 2 `@id` and 
 
 ## Example
 
-{% include manifest_links.html viewers="Mirador, Annona, Clover" manifest="manifest.json" %}
+{% include manifest_links.html viewers="Mirador, Annona, Clover, Glycerine Viewer" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" config='data-line="36-42"' %}
 

--- a/recipe/0006-text-language/index.md
+++ b/recipe/0006-text-language/index.md
@@ -8,6 +8,7 @@ viewers:
  - UV
  - Mirador  
  - Annona
+ - Glycerine Viewer
 topic: basic
 property: label, summary, metadata, requiredStatement
 code:
@@ -40,7 +41,7 @@ To see the language choice in the linked viewers, open the settings menu (gear i
 
 The image in this example was sourced via Wikimedia Commons and is public domain.
 
-{% include manifest_links.html viewers="UV, Mirador, Annona" manifest="manifest.json" %}
+{% include manifest_links.html viewers="UV, Mirador, Annona, Glycerine Viewer" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" config='data-line="6-11, 16-21, 24-26, 31-36, 39-44, 49-54, 58-63, 66-68"' %}
 

--- a/recipe/0007-string-formats/index.md
+++ b/recipe/0007-string-formats/index.md
@@ -9,6 +9,7 @@ viewers:
  - Mirador  
  - Annona
  - Clover
+ - Glycerine Viewer
 topic: property
 property: label, summary, metadata, requiredStatement
 code:
@@ -31,7 +32,7 @@ For security reasons, clients are expected to allow only `a`, `b`, `br`, `i`, `i
 
 ## Example
 
-{% include manifest_links.html viewers="UV, Mirador, Annona, Clover" manifest="manifest.json" %}
+{% include manifest_links.html viewers="UV, Mirador, Annona, Clover, Glycerine Viewer" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" config='data-line="7,12,24,38"' %}
 

--- a/recipe/0008-rights/index.md
+++ b/recipe/0008-rights/index.md
@@ -9,6 +9,7 @@ viewers:
  - Mirador
  - Annona
  - Clover
+ - Glycerine Viewer
 topic: property
 property: rights, requiredStatement
 code:
@@ -39,7 +40,7 @@ None known.
 
 ## Example
 
-{% include manifest_links.html viewers="UV, Mirador, Annona, Clover" manifest="manifest.json" %}
+{% include manifest_links.html viewers="UV, Mirador, Annona, Clover, Glycerine Viewer" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" config='data-line="15-27"' %}
 

--- a/recipe/0009-book-1/index.md
+++ b/recipe/0009-book-1/index.md
@@ -9,6 +9,7 @@ viewers:
  - Mirador  
  - Annona
  - Clover
+ - Glycerine Viewer
 topic: 
  - image
  - basic
@@ -36,7 +37,7 @@ You should also consider providing a [thumbnail][prezi3-thumbnail] for each Canv
 
 ## Example
 
-{% include manifest_links.html viewers="UV, Mirador, Annona, Clover" manifest="manifest.json" %}
+{% include manifest_links.html viewers="UV, Mirador, Annona, Clover, Glycerine Viewer" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" %}
 

--- a/recipe/0019-html-in-annotations/index.md
+++ b/recipe/0019-html-in-annotations/index.md
@@ -7,6 +7,7 @@ summary: "tbc"
 viewers:
   - Mirador
   - Annona
+  - Glycerine Viewer
 topic: 
  - basic
 code:
@@ -43,7 +44,7 @@ If you have requirements outside of these rules you may be able to configure a c
 
 This example Manifest contains an embedded Annotation containing the HTML text "Göttinger Marktplatz mit Gänseliesel Brunnen" with a link to the Wikipedia Article "Gänseliesel-Brunnen (Göttingen)" behind the words "Gänseliesel Brunnen" and an image of the Wikipedia logo. The Annotation has the motivation `commenting` targeting the whole Canvas. The Annotation is the single content of an Annotation Page contained in the `annotations` property of the Canvas.
 
-{% include manifest_links.html viewers="Mirador,Annona" manifest="manifest.json" %}
+{% include manifest_links.html viewers="Mirador,Annona, Glycerine Viewer" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" config='data-line="53-58"' %}
 

--- a/recipe/0021-tagging/index.md
+++ b/recipe/0021-tagging/index.md
@@ -7,6 +7,7 @@ summary: "Tagging as a basic Annotation"
 viewers:
  - Mirador  
  - Annona
+ - Glycerine Viewer
 topic: annotation
 code:
  - iiif-prezi3
@@ -32,7 +33,7 @@ In this Manifest, we use a photograph of Göttingen from the 2019 IIIF annual co
 
 Because the statue is not the sole or dominant element of the photo, we've targeted the tag to a portion of the photo using fragment selector syntax.
 
-{% include manifest_links.html viewers="Mirador,Annona" manifest="manifest.json" %}
+{% include manifest_links.html viewers="Mirador,Annona,Glycerine Viewer" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" config='data-line="44-63"' %}
 

--- a/recipe/0029-metadata-anywhere/index.md
+++ b/recipe/0029-metadata-anywhere/index.md
@@ -10,6 +10,7 @@ viewers:
  - Annona
  - id: Clover
    support: partial
+ - Glycerine Viewer
 topic: property
 property: metadata
 ---
@@ -36,7 +37,7 @@ Note: Clover supports Metadata at the Manifest level but not down at the Canvas.
 
 Credit: *John Dee performing an experiment before Queen Elizabeth I*. Oil painting by Henry Gillard Glindoni. Credit: Wellcome Collection. Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)
 
-{% include manifest_links.html viewers="UV, Mirador, Annona, Clover" manifest="manifest.json" %}
+{% include manifest_links.html viewers="UV, Mirador, Annona, Clover, Glycerine Viewer" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" config='data-line="10-59, 83-96, 136-149"' %}
 

--- a/recipe/0032-collection/index.md
+++ b/recipe/0032-collection/index.md
@@ -9,6 +9,7 @@ viewers:
  - Mirador
  - Annona
  - Clover
+ - Glycerine Viewer
 topic:
  - basic
 ---
@@ -50,19 +51,19 @@ Note: Each supporting viewer has a distinct method for toggling between Collecti
 
 **Example Collection**
 
-{% include manifest_links.html viewers="UV, Mirador, Annona, Clover" manifest="collection.json" %}
+{% include manifest_links.html viewers="UV, Mirador, Annona, Clover, Glycerine Viewer" manifest="collection.json" %}
 
 {% include jsonviewer.html src="collection.json" %}
 
 **Example Manifest for _The Gulf Stream_**
 
-{% include manifest_links.html viewers="UV, Mirador, Annona, Clover" manifest="manifest-01.json" %}
+{% include manifest_links.html viewers="UV, Mirador, Annona, Clover, Glycerine Viewer" manifest="manifest-01.json" %}
 
 {% include jsonviewer.html src="manifest-01.json" %}
 
 **Example Manifest for _Northeaster_**
 
-{% include manifest_links.html viewers="UV, Mirador, Annona, Clover" manifest="manifest-02.json" %}
+{% include manifest_links.html viewers="UV, Mirador, Annona, Clover, Glycerine Viewer" manifest="manifest-02.json" %}
 
 {% include jsonviewer.html src="manifest-02.json" %}
 

--- a/recipe/0046-rendering/index.md
+++ b/recipe/0046-rendering/index.md
@@ -8,6 +8,7 @@ viewers:
  - Mirador  
  - Annona
  - Clover
+ - Glycerine Viewer
 topic: property
 property: rendering
 ---
@@ -43,7 +44,7 @@ In this example, a PDF is made available for the program as a whole, and as such
 
 To see the property in action in Mirador, toggle the sidebar by activating the three-line ("hamburger") menu in the upper left-hand corner of the content window. You should then, in the "Related" area, see the link under the "Alternate formats" heading.
 
-{% include manifest_links.html viewers="Mirador,Annona,Clover" manifest="manifest.json" %}
+{% include manifest_links.html viewers="Mirador,Annona,Clover,Glycerine Viewer" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" config='data-line="16-27"' %}
 

--- a/recipe/0047-homepage/index.md
+++ b/recipe/0047-homepage/index.md
@@ -8,6 +8,7 @@ viewers:
   - Mirador
   - Clover
   - Annona
+  - Glycerine Viewer
 topic: property
 property: homepage
 ---
@@ -36,7 +37,7 @@ In this example we have a Manifest representing an object housed at the Getty Mu
 
 _Laocöon_. Credit: Getty.
 
-{% include manifest_links.html viewers="Mirador, Clover, Annona" manifest="manifest.json" %}
+{% include manifest_links.html viewers="Mirador, Clover, Annona, Glycerine Viewer" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" config='data-line="10-24"' %}
 

--- a/recipe/0053-seeAlso/index.md
+++ b/recipe/0053-seeAlso/index.md
@@ -8,6 +8,7 @@ viewers:
  - Mirador  
  - Annona
  - Clover
+ - Glycerine Viewer
 topic: property
 property: seeAlso
 ---
@@ -45,7 +46,7 @@ A consistent URI to use for the `profile` value for MODS can be found in [the II
 
 To see the property in action in Mirador, toggle the sidebar by activating the three-line ("hamburger") menu in the upper left-hand corner of the content window. You should then, in the "Related" area, see the link in the "Related" section under the "See also" subheading.
 
-{% include manifest_links.html viewers="Mirador, Annona, Clover" manifest="manifest.json" %}
+{% include manifest_links.html viewers="Mirador, Annona, Clover, Glycerine Viewer" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" config='data-line="16-28"' %}
 

--- a/recipe/0117-add-image-thumbnail/index.md
+++ b/recipe/0117-add-image-thumbnail/index.md
@@ -7,6 +7,7 @@ summary: "Display a thumbnail image for a resource other than a Canvas, such tha
 viewers:
  - Mirador  
  - Clover
+ - Glycerine Viewer
 topic: property
 property: thumbnail
 ---
@@ -31,7 +32,7 @@ None known.
 
 This example uses an image of the cover of the same kabuki performance program as in the recipe for [Viewing direction and its effect on navigation][0010]. This image, though, has a color bar and the Manifest contains an explicit `thumbnail` property for the Manifest. In this particular use case, to avoid having a Manifest thumbnail image with a color calibration bar, you can choose to declare a thumbnail from a completely different image. Keep in mind that this thumbnail is just for the Manifest; no thumbnail has been explicitly set for the sole resource, so the supporting viewers should use the resource's IIIF Image service to create one.
 
-{% include manifest_links.html viewers="Mirador, Clover" manifest="manifest.json" %}
+{% include manifest_links.html viewers="Mirador, Clover, Glycerine Viewer" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" %}
 

--- a/recipe/0118-multivalue/index.md
+++ b/recipe/0118-multivalue/index.md
@@ -8,6 +8,7 @@ viewers:
  - UV
  - Mirador 
  - Annona 
+ - Glycerine Viewer
 topic: property
 property: label, summary, metadata, requiredStatement
 ---
@@ -30,7 +31,7 @@ None
 
 In this example, the work has multiple titles in both English and French. The Manifest `label` provides a single title in French within a single-value array (lines 6–8). The alternative titles are provided in the `metadata` property in both English and French, each with variants contained within two separate arrays -- one array for English (lines 18–21) and one for French (lines 22–25). In the `summary` property (lines 30–32) the value is included as a single-string array.
 
-{% include manifest_links.html viewers="UV, Mirador, Annona" manifest="manifest.json" %}
+{% include manifest_links.html viewers="UV, Mirador, Annona, Glycerine Viewer" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" config='data-line="6-8, 18-21, 22-25, 30-32"'%}
 

--- a/recipe/0135-annotating-point-in-canvas/index.md
+++ b/recipe/0135-annotating-point-in-canvas/index.md
@@ -5,6 +5,7 @@ layout: recipe
 tags: image
 summary: "This recipe explains how to annotate a specific point of an image."
 viewers:
+ - Glycerine Viewer
 topic:
  - annotation
 ---
@@ -24,7 +25,7 @@ Viewers might consider implementing scale-independent point markers so that they
 
 This example uses a leaflet with a map and a guide supplied by the Library of Congress Geography and Map Division, it shows how we can annotate some locations expressed in the map.
 
-{% include manifest_links.html viewers="" manifest="manifest.json" %}
+{% include manifest_links.html viewers="Glycerine Viewer" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" config='data-line="74-82"' %}
 

--- a/recipe/0202-start-canvas/index.md
+++ b/recipe/0202-start-canvas/index.md
@@ -7,6 +7,7 @@ summary: "This manifest uses the 'start' property to specify which Canvas the cl
 viewers:
  - Mirador  
  - Annona
+ - Glycerine Viewer
 topic: 
  - image
  - property
@@ -29,7 +30,7 @@ For an example of the `start` property using a Specific Resource with a Selector
 
 This example shows a Manifest with multiple Canvases for a book object. The `start` property specifies loading the Manifest at the second Canvas. Note that all Canvases are still displayed in the viewer and the user is able to navigate back to the first Canvas using the viewer navigation controls.
 
-{% include manifest_links.html viewers="Mirador,Annona" manifest="manifest.json" %}
+{% include manifest_links.html viewers="Mirador,Annona,Glycerine Viewer" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" config='data-line="10-13"'%}
 

--- a/recipe/0234-provider/index.md
+++ b/recipe/0234-provider/index.md
@@ -7,6 +7,7 @@ summary: "Include a rich set of information for each content contributor so clie
 viewers:
  - id: Mirador
    support: partial
+ - Glycerine Viewer
 topic: property
 property: provider
 ---
@@ -36,7 +37,7 @@ In this example, we reuse the front page of a kabuki playbill that was contribut
 
 Only Mirador implements `provider`, and only partially. The property must be on the Manifest level, Mirador will only display the text from a `label` and the image from a  `logo` under `provider`, and the information will only be found in the list of manifests.
 
-{% include manifest_links.html viewers="Mirador" manifest="manifest.json" %}
+{% include manifest_links.html viewers="Mirador, Glycerine Viewer" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" config='data-line="15-82"' %}
 

--- a/recipe/0258-tagging-external-resource/index.md
+++ b/recipe/0258-tagging-external-resource/index.md
@@ -5,6 +5,7 @@ layout: recipe
 tags: annotation, tagging, linking
 summary: "Connect a tagging annotation to an external resource"
 viewers:
+ - Glycerine Viewer
 topic: annotation
 ---
 
@@ -31,7 +32,7 @@ Using multiple `body` properties, as shown here, does not have any predictable c
 
 No viewers currently implement this tagging approach.
 
-{% include manifest_links.html viewers="" manifest="manifest.json" %}
+{% include manifest_links.html viewers="Glycerine Viewer" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" config="data-line='49-66'"%}
 

--- a/recipe/0261-non-rectangular-commenting/index.md
+++ b/recipe/0261-non-rectangular-commenting/index.md
@@ -7,6 +7,7 @@ summary: "For a IIIF resource, you would like to add a simple annotation to the 
 viewers:
  - Mirador
  - Annona
+ - Glycerine Viewer
 topic: annotation
 ---
 
@@ -53,7 +54,7 @@ This approach should not be used to describe non-rotated rectangular regions.
 
 In this Manifest, we are highlighting a fountain with a statue on top of it and imagining that we want to be fairly precise in our highlight. The client should not show the bounding box on the image.
 
-{% include manifest_links.html viewers="Mirador,Annona" manifest="manifest.json" %}
+{% include manifest_links.html viewers="Mirador,Annona,Glycerine Viewer" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" config='data-line="44-70"' %}
 

--- a/recipe/0266-full-canvas-annotation/index.md
+++ b/recipe/0266-full-canvas-annotation/index.md
@@ -7,6 +7,7 @@ summary: "tbc"
 viewers:
  - Mirador  
  - Annona
+ - Glycerine Viewer
 topic: annotation
 ---
 
@@ -36,7 +37,7 @@ The semantic of annotating the full Canvas as a whole can be specified by either
 
 This example Manifest contains an embedded Annotation containing the text "Göttinger Marktplatz mit Gänseliesel Brunnen" with the motivation `commenting` targeting the whole Canvas. The Annotation is the single content of an Annotation Page contained in the `annotations` property of the Canvas.
 
-{% include manifest_links.html viewers="Mirador,Annona" manifest="manifest.json" %}
+{% include manifest_links.html viewers="Mirador,Annona,Glycerine Viewer" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" config='data-line="44-63"' %}
 

--- a/recipe/0269-embedded-or-referenced-annotations/index.md
+++ b/recipe/0269-embedded-or-referenced-annotations/index.md
@@ -8,6 +8,7 @@ topic: annotation
 viewers:
  - Mirador
  - Annona
+ - Glycerine Viewer
 ---
 
 ## Use Case
@@ -51,7 +52,7 @@ The rendering of this referenced Annotation should be virtually indistiguishable
 
 ### Manifest file
 
-{% include manifest_links.html viewers="Mirador, Annona" manifest="manifest.json" %}
+{% include manifest_links.html viewers="Mirador, Annona, Glycerine Viewer" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" config='data-line="44-49"' %}
 

--- a/recipe/0283-missing-image/index.md
+++ b/recipe/0283-missing-image/index.md
@@ -7,6 +7,7 @@ summary: "Represent a missing image from a paged object in a sequence."
 viewers:
  - UV
  - Mirador
+ - Glycerine Viewer
 topic:
  - image
  - basic

--- a/recipe/0299-region/index.md
+++ b/recipe/0299-region/index.md
@@ -6,6 +6,7 @@ tags: [fragment]
 summary: "Presenting a spatial region of a IIIF image resource independently"
 viewers:
  - Annona
+ - Glycerine Viewer
 topic:
  - basic
 ---
@@ -38,7 +39,7 @@ This recipe can not be applied to pulling a temporal segment from a time-based I
 
 In this example we use an ImageApiSelector on the `body` of the Manifest's sole Annotation to retrieve a single article selection from the 16 February 1925 issue of _Berliner Tageblatt_. The article discusses a meeting including Neville Chamberlain of Great Britain.
 
-{% include manifest_links.html viewers="Annona" manifest="manifest.json" %}
+{% include manifest_links.html viewers="Annona, Glycerine Viewer" manifest="manifest.json" %}
 {% include jsonviewer.html src="manifest.json" config="data-line='14-15,25-48'" %}
 
 ## Related Recipes

--- a/recipe/0306-linking-annotations-to-manifests/index.md
+++ b/recipe/0306-linking-annotations-to-manifests/index.md
@@ -38,7 +38,7 @@ Annotation Page file
 {% include jsonviewer.html src="annotationpage.json" config='data-line="16-33"' %}
 
 Manifest file
-{% include manifest_links.html viewers="Mirador, Annona" manifest="manifest.json" %}
+{% include manifest_links.html viewers="Mirador, Annona, Glycerine Viewer" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" config='data-line="44-49"' %}
 

--- a/recipe/0377-image-in-annotation/index.md
+++ b/recipe/0377-image-in-annotation/index.md
@@ -6,6 +6,7 @@ tags: [annotation]
 summary: "Provides an image in an annotation"
 viewers:
   - Annona
+  - Glycerine Viewer
 topic: 
  - basic
 ---
@@ -26,7 +27,7 @@ Our supplementary image is not part of the Canvas content, thus it must not have
 
 The main content is a photo of a square in Göttingen, which shows, among others things, a fountain. We wanted to show the lights on the fountain during the night, so we associated the part of the Canvas containing the fountain with an Annotation consisting of a picture of the fountain at night and a text comment.
 
-{% include manifest_links.html viewers="Annona" manifest="manifest.json" %}
+{% include manifest_links.html viewers="Annona, Glycerine Viewer" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" config="data-line='49-66'" %}
 

--- a/recipe/matrix.md
+++ b/recipe/matrix.md
@@ -11,6 +11,7 @@ viewers:
   - Clover
   - Navplace Viewer
   - Ramp
+  - Glycerine Viewer
 topics:
   - basic
   - property


### PR DESCRIPTION
From original [pull request](https://github.com/IIIF/cookbook-recipes/pull/490):

"Initially designed for the sophisticated annotation features of [Glycerine Workbench](https://glycerine.io/), [Glycerine Viewer](https://github.com/Systemik-Solutions/glycerine-viewer) has been released as an open source IIIF viewer to support IIIF manifests and compliant annotations built with other tools. Developed with a contemporary Vue 3 framework, Glycerine Viewer has an elegant interface, supports the IIIF Presentation API and provides the most comprehensive annotation feature set of any IIIF Viewer."