### PR TITLE
Changes to recipe support of Glycerine Viewer

### DIFF
--- a/recipe/0030-multi-volume/index.md
+++ b/recipe/0030-multi-volume/index.md
@@ -8,6 +8,7 @@ viewers:
  - UV
  - Mirador  
  - Annona
+ - Glycerine Viewer
 topic: structure
 ---
 
@@ -35,19 +36,19 @@ Following the Collection resource are the two Manifests for vol. 1 and vol. 2 th
 
 **Example Collection for the multi-volume work *青楼絵本年中行事 [Seirō ehon nenjū gyōji]*:**
 
-{% include manifest_links.html viewers="UV, Mirador, Annona" manifest="collection.json" %}
+{% include manifest_links.html viewers="UV, Mirador, Annona, Glycerine Viewer" manifest="collection.json" %}
 
 {% include jsonviewer.html src="collection.json" config='data-line="4, 10-12"' %}
 
 **Example Manifest for vol. 1 of *青楼絵本年中行事 [Seirō ehon nenjū gyōji]*:**
 
-{% include manifest_links.html viewers="UV, Mirador, Annona" manifest="manifest_v1.json" %}
+{% include manifest_links.html viewers="UV, Mirador, Annona, Glycerine Viewer" manifest="manifest_v1.json" %}
 
 {% include jsonviewer.html src="manifest_v1.json" %}
 
 **Example Manifest for vol. 2 of *青楼絵本年中行事 [Seirō ehon nenjū gyōji]*:**
 
-{% include manifest_links.html viewers="UV, Mirador, Annona" manifest="manifest_v2.json" %}
+{% include manifest_links.html viewers="UV, Mirador, Annona, Glycerine Viewer" manifest="manifest_v2.json" %}
 
 {% include jsonviewer.html src="manifest_v2.json" %}
 

--- a/recipe/0068-newspaper/index.md
+++ b/recipe/0068-newspaper/index.md
@@ -8,6 +8,7 @@ viewers:
  - Mirador
  - Annona
  - UV
+ - Glycerine Viewer
 topic: 
  - realWorldObject
 ---
@@ -82,21 +83,21 @@ To demonstrate the files that might be included in even a basic newspaper presen
 
 We won't display all of these here, to keep the recipe readable. However, we've inclued the Manifest for the title (structured as a IIIF Collection), thinking it will provide the best initial utility. Notable lines of the Manifest are highlighted.
 
-Viewer support for any particular feature will depend on the viewer and any customizations or extensions. Below is a table showing viewer support as of March 2023 for features noted in this recipe.
+Viewer support for any particular feature will depend on the viewer and any customizations or extensions. Below is a table showing viewer support as of May 2024 for features noted in this recipe.
 
-| IIIF component | Viewer Support (February 2023) |
+| IIIF component | Viewer Support (May 2024) |
 |-----------|------|
-| Collection | Mirador, Annona, Universal Viewer, Clover |
-| Manifest per issue | Mirador, Annona, Universal Viewer, Clover |
+| Collection | Mirador, Annona, Universal Viewer, Clover, Glycerine Viewer |
+| Manifest per issue | Mirador, Annona, Universal Viewer, Clover, Glycerine Viewer |
 | `navDate` | Universal Viewer |
-| OCR in Annotations | Annona |
-| ALTO via `rendering` | none (but may be possible with a viewer plugin) |
-| `seeAlso` for dataset version | Annona, Mirador |
+| OCR in Annotations | Annona, Glycerine Viewer |
+| ALTO via `rendering` | Glycerine Viewer |
+| `seeAlso` for dataset version | Annona, Mirador, Glycerine Viewer |
 {: .api-table style="max-width: 780px;"}
 
 Similarly, the quality of the OCR as well as the formatting and positioning data of the Annotations containing it will determine how useful it is. IIIF Presentation v3 only provides a standard for structuring it and communicating layout to a viewer.
 
-{% include manifest_links.html viewers="Mirador, Annona, UV, Clover" manifest="newspaper_title-collection.json" %}
+{% include manifest_links.html viewers="Mirador, Annona, UV, Clover, Glycerine Viewer" manifest="newspaper_title-collection.json" %}
 
 {% include jsonviewer.html src="newspaper_title-collection.json" config='data-line="7-11,14-27,78-85,86-107"' %}
 

--- a/recipe/0258-tagging-external-resource/index.md
+++ b/recipe/0258-tagging-external-resource/index.md
@@ -30,8 +30,6 @@ In this example, we continue our use of a photograph of a square in Göttingen, 
 
 Using multiple `body` properties, as shown here, does not have any predictable consequences for a viewer's handling of the data. With this in mind, each `body` in this Manifest could stand alone.
 
-No viewers currently implement this tagging approach.
-
 {% include manifest_links.html viewers="Glycerine Viewer" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" config="data-line='49-66'"%}


### PR DESCRIPTION
Related to https://github.com/IIIF/cookbook-recipes/pull/491

- Have added the Glycerine Viewer into recipes 0068 and 0030
- Removed the "No viewers currently implement this tagging approach" from recipe 0258