### PR TITLE
Add IIIF Curation Viewer

### DIFF
--- a/recipe/0001-mvm-image/index.md
+++ b/recipe/0001-mvm-image/index.md
@@ -11,6 +11,7 @@ viewers:
  - Clover
  - Glycerine Viewer
  - Theseus
+ - Curation
 topic: 
  - basic
  - image

--- a/recipe/0004-canvas-size/index.md
+++ b/recipe/0004-canvas-size/index.md
@@ -9,6 +9,7 @@ viewers:
  - Mirador
  - Annona
  - Theseus
+ - Curation
 topic: image
 code:
  - iiif-prezi3
@@ -39,7 +40,7 @@ The aspect ratio should be consistent between your source image and Canvas. Othe
 
 This example shows a Manifest with a single Canvas that has height and width dimensions three times the pixel dimensions of the image in order to construct a Canvas with both dimensions greater than 1000px.
 
-{% include manifest_links.html viewers="UV, Mirador, Annona, Theseus" manifest="manifest.json" %}
+{% include manifest_links.html viewers="UV, Mirador, Annona, Theseus, Curation" manifest="manifest.json" %}
 {% include jsonviewer.html src="manifest.json" config="data-line='14-15,29-30'"%}
 
 # Related recipes

--- a/recipe/0005-image-service/index.md
+++ b/recipe/0005-image-service/index.md
@@ -10,6 +10,7 @@ viewers:
  - Clover
  - Glycerine Viewer
  - Theseus
+ - Curation
 topic:
  - basic
  - image
@@ -37,7 +38,7 @@ Though a version 3 Manifest may specify a service using the version 2 `@id` and 
 
 ## Example
 
-{% include manifest_links.html viewers="Mirador, Annona, Clover, Glycerine Viewer, Theseus" manifest="manifest.json" %}
+{% include manifest_links.html viewers="Mirador, Annona, Clover, Glycerine Viewer, Theseus, Curation" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" config='data-line="36-42"' %}
 

--- a/recipe/0006-text-language/index.md
+++ b/recipe/0006-text-language/index.md
@@ -10,6 +10,7 @@ viewers:
  - Annona
  - Glycerine Viewer
  - Theseus
+ - Curation
 topic: basic
 property: label, summary, metadata, requiredStatement
 code:
@@ -42,7 +43,7 @@ To see the language choice in the linked viewers, open the settings menu (gear i
 
 The image in this example was sourced via Wikimedia Commons and is public domain.
 
-{% include manifest_links.html viewers="UV, Mirador, Annona, Glycerine Viewer, Theseus" manifest="manifest.json" %}
+{% include manifest_links.html viewers="UV, Mirador, Annona, Glycerine Viewer, Theseus, Curation" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" config='data-line="6-11, 16-21, 24-26, 31-36, 39-44, 49-54, 58-63, 66-68"' %}
 

--- a/recipe/0007-string-formats/index.md
+++ b/recipe/0007-string-formats/index.md
@@ -11,6 +11,7 @@ viewers:
  - Clover
  - Glycerine Viewer
  - Theseus
+ - Curation
 topic: property
 property: label, summary, metadata, requiredStatement
 code:
@@ -33,7 +34,7 @@ For security reasons, clients are expected to allow only `a`, `b`, `br`, `i`, `i
 
 ## Example
 
-{% include manifest_links.html viewers="UV, Mirador, Annona, Clover, Glycerine Viewer, Theseus" manifest="manifest.json" %}
+{% include manifest_links.html viewers="UV, Mirador, Annona, Clover, Glycerine Viewer, Theseus, Curation" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" config='data-line="7,12,24,38"' %}
 

--- a/recipe/0008-rights/index.md
+++ b/recipe/0008-rights/index.md
@@ -11,6 +11,7 @@ viewers:
  - Clover
  - Glycerine Viewer
  - Theseus
+ - Curation
 topic: property
 property: rights, requiredStatement
 code:
@@ -41,7 +42,7 @@ None known.
 
 ## Example
 
-{% include manifest_links.html viewers="UV, Mirador, Annona, Clover, Glycerine Viewer, Theseus" manifest="manifest.json" %}
+{% include manifest_links.html viewers="UV, Mirador, Annona, Clover, Glycerine Viewer, Theseus, Curation" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" config='data-line="15-27"' %}
 

--- a/recipe/0009-book-1/index.md
+++ b/recipe/0009-book-1/index.md
@@ -11,6 +11,7 @@ viewers:
  - Clover
  - Glycerine Viewer
  - Theseus
+ - Curation
 topic:
  - image
  - basic
@@ -38,7 +39,7 @@ You should also consider providing a [thumbnail][prezi3-thumbnail] for each Canv
 
 ## Example
 
-{% include manifest_links.html viewers="UV, Mirador, Annona, Clover, Glycerine Viewer, Theseus" manifest="manifest.json" %}
+{% include manifest_links.html viewers="UV, Mirador, Annona, Clover, Glycerine Viewer, Theseus, Curation" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" %}
 

--- a/recipe/0010-book-2-viewing-direction/index.md
+++ b/recipe/0010-book-2-viewing-direction/index.md
@@ -9,6 +9,7 @@ viewers:
  - Mirador
  - Annona
  - Theseus
+ - Curation
 topic:
  - image
  - property
@@ -41,7 +42,7 @@ None known
 
 This Manifest shows the playbill for "Akiba gongen kaisen-banashi," "Futatsu chōchō kuruwa nikki", and "Godairiki koi no fūjime", kabuki performances at the Chikugo Theater in Osaka, from the fifth month of Kaei 2 (May, 1849).
 
-{% include manifest_links.html viewers="UV, Mirador, Annona, Theseus" manifest="manifest-rtl.json" %}
+{% include manifest_links.html viewers="UV, Mirador, Annona, Theseus, Curation" manifest="manifest-rtl.json" %}
 
 {% include jsonviewer.html src="manifest-rtl.json" config='data-line="15"' %}
 

--- a/recipe/0029-metadata-anywhere/index.md
+++ b/recipe/0029-metadata-anywhere/index.md
@@ -12,6 +12,7 @@ viewers:
    support: partial
  - Glycerine Viewer
  - Theseus
+ - Curation
 topic: property
 property: metadata
 ---
@@ -38,7 +39,7 @@ Note: Clover supports Metadata at the Manifest level but not down at the Canvas.
 
 Credit: *John Dee performing an experiment before Queen Elizabeth I*. Oil painting by Henry Gillard Glindoni. Credit: Wellcome Collection. Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)
 
-{% include manifest_links.html viewers="UV, Mirador, Annona, Clover, Glycerine Viewer, Theseus" manifest="manifest.json" %}
+{% include manifest_links.html viewers="UV, Mirador, Annona, Clover, Glycerine Viewer, Theseus, Curation" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" config='data-line="10-59, 83-96, 136-149"' %}
 

--- a/recipe/0118-multivalue/index.md
+++ b/recipe/0118-multivalue/index.md
@@ -10,6 +10,7 @@ viewers:
  - Annona
  - Glycerine Viewer
  - Theseus
+ - Curation
 topic: property
 property: label, summary, metadata, requiredStatement
 ---
@@ -32,7 +33,7 @@ None
 
 In this example, the work has multiple titles in both English and French. The Manifest `label` provides a single title in French within a single-value array (lines 6–8). The alternative titles are provided in the `metadata` property in both English and French, each with variants contained within two separate arrays -- one array for English (lines 18–21) and one for French (lines 22–25). In the `summary` property (lines 30–32) the value is included as a single-string array.
 
-{% include manifest_links.html viewers="UV, Mirador, Annona, Glycerine Viewer, Theseus" manifest="manifest.json" %}
+{% include manifest_links.html viewers="UV, Mirador, Annona, Glycerine Viewer, Theseus, Curation" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" config='data-line="6-8, 18-21, 22-25, 30-32"'%}
 

--- a/recipe/0283-missing-image/index.md
+++ b/recipe/0283-missing-image/index.md
@@ -9,6 +9,7 @@ viewers:
  - Mirador
  - Glycerine Viewer
  - Theseus
+ - Curation
 topic:
  - image
  - basic

--- a/recipe/matrix.md
+++ b/recipe/matrix.md
@@ -14,6 +14,7 @@ viewers:
   - Aviary
   - Glycerine Viewer
   - Theseus
+  - Curation
 topics:
   - basic
   - property


### PR DESCRIPTION
On August 27, 2024, we released a new version of the “IIIF Curation Platform” (including the “IIIF Curation Viewer”) to support IIIF Presentation API 3.0. This pull request is to reflect the viewer’s compatibility status.
http://codh.rois.ac.jp/icp/prezi-3/