### PR TITLE
Collapse unnecessary array in recipe 0346

### DIFF
--- a/recipe/0346-multilingual-annotation-body/manifest.json
+++ b/recipe/0346-multilingual-annotation-body/manifest.json
@@ -53,8 +53,7 @@
 			  "id": "{{ id.path }}/annotation/p0001-comment",
 			  "type": "Annotation",
 			  "motivation": "commenting",
-			  "body": [
-			  {
+			  "body": {
 			  	"type": "Choice",
 			  	"items": [
 					{
@@ -70,8 +69,7 @@
 						"format": "text/plain"
 					}
 			  	]
-			  	}
-			  ],
+			  },
 			  "target": "{{ id.path }}/canvas/p1#xywh=1650,1200,925,1250"
 			}
 		  ]


### PR DESCRIPTION
Not a big deal, but the recipe in 0346 has an annotation body that has an unnecessary array (i.e., an array that wraps a single JSON object). I asked on the cookbooks' Slack channel and the thought was it's just a copypasta that slipped by in the creation process. So, I'm submitting a PR to clean it up.  :-)