### PR TITLE
Clean up extra space typo in recipe 0318

### DIFF
--- a/recipe/0318-navPlace-navDate/manifest-5.json
+++ b/recipe/0318-navPlace-navDate/manifest-5.json
@@ -7,7 +7,7 @@
     "type": "Manifest",
     "label": {
       "en": [
-        " A View of Trajan's Forum, Rome, 1821"
+        "A View of Trajan's Forum, Rome, 1821"
       ]
     },
     "navDate": "1821-01-01T00:00:00+00:00",


### PR DESCRIPTION
Fix a small typo that adds a space at the front of a text value.