### PR TITLE
Add Glycerine Viewer support to 0309 annotation collection recipe

### DIFF
--- a/recipe/0309-annotation-collection/index.md
+++ b/recipe/0309-annotation-collection/index.md
@@ -5,6 +5,7 @@ layout: recipe
 tags: [tbc]
 summary: "tbc"
 viewers:
+ - Glycerine Viewer
 topic: 
  - basic
 ---
@@ -51,7 +52,7 @@ The second AnnotationPage with Annotations on the second Canvas: [anno_p2.json](
 
 The Manifest containing the two Canvases and referencing the Annotation Pages:
 
-{% include manifest_links.html viewers="" manifest="manifest.json" %}
+{% include manifest_links.html viewers="Glycerine Viewer" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" config='data-line="66-80,124-138"' %}
 


### PR DESCRIPTION
Glycerine Viewer now supports reading annotations from annotation collections and filtering annotations by collections.

Demo URL:
https://demo.viewer.glycerine.io/viewer?iiif-content=https://iiif.io/api/cookbook/recipe/0309-annotation-collection/manifest.json

To filter by annotation collection, set the collection name in "Settings -> Show" dropdown and the viewer will only display the annotations from that collection. Works best if there are multiple annotation collections involved.

