### PR TITLE
Add IIIF Curation Viewer

### DIFF
--- a/recipe/0154-geo-extension/index.md
+++ b/recipe/0154-geo-extension/index.md
@@ -8,6 +8,7 @@ layout: recipe
 viewers:
  - Navplace Viewer
  - Theseus
+ - Curation
 ---
 
 ### Use Case
@@ -33,7 +34,7 @@ The map shows the location of the object represented in the image, the Laocoön 
 The Manifest contains one Canvas with a photograph painted onto it. The `navPlace` property in the Manifest stores geographic information about the bronze in the photograph, in this case the bronze's current location. `navPlace` contains GeoJSON-LD, and a client can parse GeoJSON features from `navPlace`. These GeoJSON features are rendered as geometric shapes by web mapping platforms. Data from the resource such as an image URL, label or summary is connected with those shapes via [`properties`](https://tools.ietf.org/html/rfc7946#section-3.2) in GeoJSON, but this is not a required step for seeing the shape on the map.
 To see an example using a polygonal shape see [Represent Canvas Fragment as a Geographic Area in a Web Mapping Client][0139].
 
-{% include manifest_links.html viewers="Navplace Viewer, Theseus" manifest="manifest.json" %}
+{% include manifest_links.html viewers="Navplace Viewer, Theseus, Curation" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" config='data-line="3, 13-39"' %}
 


### PR DESCRIPTION
"IIIF Curation Viewer" now supports displaying the 'navPlace' and 'navDate' properties on the IIIF manifests (since version 2.1, released in September 2025).
https://x.com/rois_codh/status/1965975626328027497

Demo:
https://codh.rois.ac.jp/software/iiif-curation-viewer/demo/?manifest=https://iiif.io/api/cookbook/recipe/0154-geo-extension/manifest.json&lang=en