### PR TITLE
Added Theseus to supported viewer for annotation collections (#309)

### DIFF
--- a/recipe/0309-annotation-collection/index.md
+++ b/recipe/0309-annotation-collection/index.md
@@ -6,6 +6,7 @@ tags: [tbc]
 summary: "tbc"
 viewers:
  - Glycerine Viewer
+ - Theseus
 topic: 
  - basic
 ---


### PR DESCRIPTION
# Theseus support for annotation collections

Cookbook link: https://iiif.io/api/cookbook/recipe/0309-annotation-collection/

<img width="295" height="416" alt="image" src="https://github.com/user-attachments/assets/cd094536-6765-4739-aec8-eff9c044e092" />

If there are one or more annotation collections, they will be visible in the annotation sidebar, where you can give each different colours. (Also available on the canvas itself under the annotations menu).

You can also toggle on/off different collections.

https://theseusviewer.org/?iiif-content=https%3A%2F%2Fiiif.io%2Fapi%2Fcookbook%2Frecipe%2F0309-annotation-collection%2Fmanifest.json&panel=annotations