### PR TITLE
Added Theseus support for opening multiple canvases (#540)

### DIFF
--- a/recipe/0540-link-for-opening-multiple-canvases/index.md
+++ b/recipe/0540-link-for-opening-multiple-canvases/index.md
@@ -5,6 +5,7 @@ layout: recipe
 tags: [annotation, content-state]
 summary: "Allows users to use Content State API to open two canvases at the same time."
 viewers:
+  - Theseus
 topic:
  - content-state
 ---


### PR DESCRIPTION
Cookbook link: https://iiif.io/api/cookbook/recipe/0540-link-for-opening-multiple-canvases/

This is a strange one. Because Theseus doesn't have a comparison view, I've chosen instead to create a "virtual" manifest with only resources listed. So for example, if there are 2 canvases from 2 different manfiests, it will show you only those two canvases (with required statements/rights hoisted up to the canvas). However, if you load a few canvases from the same manifest, it treats it like a sort of "filtered" view.

I think there are other cases to consider, and possibly new recipes. I'm happy with the virtual manifest for Theseus. This could be used to share "annotations I worked on" from an annotation platform, or similar - or as a form of bookmarking.


Here is the content state in the recipe:
https://theseusviewer.org/?iiif-content=https%3A%2F%2Fiiif.io%2Fapi%2Fcookbook%2Frecipe%2F0540-link-for-opening-multiple-canvases%2Fannotation.json

(Works if you paste in the encoded content state too)

<img width="970" height="546" alt="image" src="https://github.com/user-attachments/assets/0fc2cdd1-74fe-41f5-b75b-5955f9b5d235" />
