### PR TITLE
Added Theseus support to drag and drop (#599)

### DIFF
--- a/recipe/0599-drag-and-drop/index.md
+++ b/recipe/0599-drag-and-drop/index.md
@@ -5,6 +5,7 @@ layout: recipe
 tags: [content-state]
 summary: "A model for manifest publishers and viewer developers for how to facilitate and accommodate dragging a IIIF manifest from one application to another."
 viewers:
+  - Theseus
 topic:
  - content-state
 ---


### PR DESCRIPTION
Not really a link to follow, but you can drag the example from the cookbook:
https://iiif.io/api/cookbook/recipe/0599-drag-and-drop/

On to any page on Theseus to load it (incl. homepage):
https://theseusviewer.org/


I've chosen _not_ to b64 encode the content state in the URL that is generated, but maybe thats a conversation to be had.

> !NOTE
> You can also generate content state and drag and drop links from Theseus share menu. Its a bit rough right now, but it seems to work.

<img width="289" height="618" alt="image" src="https://github.com/user-attachments/assets/b15bfe5c-f5c3-4b8b-a5c5-38b08d22945e" />

(I'll get the logo added!)
