### PR TITLE
Add Triiiceratops viewer to matrix and cookbook recipes

### DIFF
--- a/_includes/viewer_link.html
+++ b/_includes/viewer_link.html
@@ -71,6 +71,11 @@
     https://tify-iiif-viewer.github.io/tify/?iiif-content={{manifest_url |strip}}
     {% endcapture %}
     {% assign default_text="View in TIFY" %}
+{% elsif include.type == 'Triiiceratops' %}
+    {% capture viewer_url %}
+    https://d-flood.github.io/triiiceratops/viewer/?iiif-content={{manifest_url |strip}}
+    {% endcapture %}
+    {% assign default_text="View in Triiiceratops" %}
 {% else %}
     {% capture default_text %}Unknown Viewer type '{{ include.type}}'{% endcapture %}
     {% capture viewer_url %}{{manifest_url |strip}}{% endcapture %}

--- a/recipe/0001-mvm-image/index.md
+++ b/recipe/0001-mvm-image/index.md
@@ -14,6 +14,7 @@ viewers:
  - Curation
  - liiive
  - TIFY
+ - Triiiceratops
 topic: 
  - basic
  - image

--- a/recipe/0004-canvas-size/index.md
+++ b/recipe/0004-canvas-size/index.md
@@ -11,6 +11,7 @@ viewers:
  - Theseus
  - Curation
  - TIFY
+ - Triiiceratops
 topic: image
 code:
  - iiif-prezi3
@@ -41,7 +42,7 @@ The aspect ratio should be consistent between your source image and Canvas. Othe
 
 This example shows a Manifest with a single Canvas that has height and width dimensions three times the pixel dimensions of the image in order to construct a Canvas with both dimensions greater than 1000px.
 
-{% include manifest_links.html viewers="UV, Mirador, Annona, Theseus, Curation, TIFY" manifest="manifest.json" %}
+{% include manifest_links.html viewers="UV, Mirador, Annona, Theseus, Curation, TIFY, Triiiceratops" manifest="manifest.json" %}
 {% include jsonviewer.html src="manifest.json" config="data-line='14-15,29-30'"%}
 
 # Related recipes

--- a/recipe/0005-image-service/index.md
+++ b/recipe/0005-image-service/index.md
@@ -13,6 +13,7 @@ viewers:
  - Curation
  - liiive
  - TIFY
+ - Triiiceratops
 topic:
  - basic
  - image
@@ -40,7 +41,7 @@ Though a version 3 Manifest may specify a service using the version 2 `@id` and 
 
 ## Example
 
-{% include manifest_links.html viewers="Mirador, Annona, Clover, Glycerine Viewer, Theseus, Curation, liiive, TIFY" manifest="manifest.json" %}
+{% include manifest_links.html viewers="Mirador, Annona, Clover, Glycerine Viewer, Theseus, Curation, liiive, TIFY, Triiiceratops" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" config='data-line="36-42"' %}
 

--- a/recipe/0006-text-language/index.md
+++ b/recipe/0006-text-language/index.md
@@ -12,6 +12,7 @@ viewers:
  - Theseus
  - Curation
  - TIFY
+ - Triiiceratops
 topic: basic
 property: label, summary, metadata, requiredStatement
 code:
@@ -48,7 +49,7 @@ Note not all viewers support all languages and users should check the viewers wi
 
 The image in this example was sourced via Wikimedia Commons and is public domain.
 
-{% include manifest_links.html viewers="UV, Mirador, Annona, Glycerine Viewer, Theseus, Curation, TIFY" manifest="manifest.json" %}
+{% include manifest_links.html viewers="UV, Mirador, Annona, Glycerine Viewer, Theseus, Curation, TIFY, Triiiceratops" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" config='data-line="6-11, 16-21, 24-26, 31-36, 39-44, 49-54, 58-63, 66-68"' %}
 

--- a/recipe/0007-string-formats/index.md
+++ b/recipe/0007-string-formats/index.md
@@ -14,6 +14,7 @@ viewers:
  - Curation
  - liiive
  - TIFY
+ - Triiiceratops
 topic: property
 property: label, summary, metadata, requiredStatement
 code:
@@ -36,7 +37,7 @@ For security reasons, clients are expected to allow only `a`, `b`, `br`, `i`, `i
 
 ## Example
 
-{% include manifest_links.html viewers="UV, Mirador, Annona, Clover, Glycerine Viewer, Theseus, Curation, liiive, TIFY" manifest="manifest.json" %}
+{% include manifest_links.html viewers="UV, Mirador, Annona, Clover, Glycerine Viewer, Theseus, Curation, liiive, TIFY, Triiiceratops" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" config='data-line="7,12,24,38"' %}
 

--- a/recipe/0008-rights/index.md
+++ b/recipe/0008-rights/index.md
@@ -13,6 +13,7 @@ viewers:
  - Theseus
  - Curation
  - TIFY
+ - Triiiceratops
 topic: property
 property: rights, requiredStatement
 code:
@@ -43,7 +44,7 @@ None known.
 
 ## Example
 
-{% include manifest_links.html viewers="UV, Mirador, Annona, Clover, Glycerine Viewer, Theseus, Curation, TIFY" manifest="manifest.json" %}
+{% include manifest_links.html viewers="UV, Mirador, Annona, Clover, Glycerine Viewer, Theseus, Curation, TIFY, Triiiceratops" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" config='data-line="15-27"' %}
 

--- a/recipe/0009-book-1/index.md
+++ b/recipe/0009-book-1/index.md
@@ -13,6 +13,7 @@ viewers:
  - Theseus
  - Curation
  - TIFY
+ - Triiiceratops
 topic:
  - image
  - basic
@@ -40,7 +41,7 @@ You should also consider providing a [thumbnail][prezi3-thumbnail] for each Canv
 
 ## Example
 
-{% include manifest_links.html viewers="UV, Mirador, Annona, Clover, Glycerine Viewer, Theseus, Curation, TIFY" manifest="manifest.json" %}
+{% include manifest_links.html viewers="UV, Mirador, Annona, Clover, Glycerine Viewer, Theseus, Curation, TIFY, Triiiceratops" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" %}
 

--- a/recipe/0010-book-2-viewing-direction/index.md
+++ b/recipe/0010-book-2-viewing-direction/index.md
@@ -14,6 +14,7 @@ viewers:
    support: partial
  - id: TIFY
    support: partial
+ - Triiiceratops
 topic:
  - image
  - property
@@ -46,7 +47,7 @@ None known
 
 This Manifest shows the playbill for "Akiba gongen kaisen-banashi," "Futatsu chōchō kuruwa nikki", and "Godairiki koi no fūjime", kabuki performances at the Chikugo Theater in Osaka, from the fifth month of Kaei 2 (May, 1849).
 
-{% include manifest_links.html viewers="UV, Mirador, Annona, Theseus, Curation, TIFY" manifest="manifest-rtl.json" %}
+{% include manifest_links.html viewers="UV, Mirador, Annona, Theseus, Curation, TIFY, Triiiceratops" manifest="manifest-rtl.json" %}
 
 {% include jsonviewer.html src="manifest-rtl.json" config='data-line="15"' %}
 
@@ -54,7 +55,7 @@ This Manifest shows the playbill for "Akiba gongen kaisen-banashi," "Futatsu ch�
 
 This Manifest represents a portion of the diary of William Lewis Sachtleben, an American long-distance cyclist who rode across Asia from Istanbul to Peking in 1891 to 1892 with Thomas Gaskell Allen Jr., his classmate from Washington University.
 
-{% include manifest_links.html viewers="UV, Mirador, Annona, TIFY" manifest="manifest-ttb.json" %}
+{% include manifest_links.html viewers="UV, Mirador, Annona, TIFY, Triiiceratops" manifest="manifest-ttb.json" %}
 
 {% include jsonviewer.html src="manifest-ttb.json" config='data-line="15"' %}
 

--- a/recipe/0011-book-3-behavior/index.md
+++ b/recipe/0011-book-3-behavior/index.md
@@ -11,6 +11,7 @@ viewers:
  - Theseus
  - id: TIFY
    support: partial
+ - Triiiceratops
 topic: property
 property:
  - behavior
@@ -47,7 +48,7 @@ The property is permissible for all resource types, but some values (`unordered`
 
 This Manifest represents an Ethiopic accordion book with a continuous layout running left-to-right. It has four images that, when using the `"behavior": "continuous"` property, will display as a single continuous image in the viewer.
 
-{% include manifest_links.html viewers="Mirador, Theseus" manifest="manifest-continuous.json" %}
+{% include manifest_links.html viewers="Mirador, Theseus, Triiiceratops" manifest="manifest-continuous.json" %}
 
 {% include jsonviewer.html src="manifest-continuous.json" config='data-line="10-12"' %}
 
@@ -55,7 +56,7 @@ This Manifest represents an Ethiopic accordion book with a continuous layout run
 
 This Manifest represents a book imaged as 2-page spreads (two facing pages in a single image). When using the `"behavior": "individuals"` property, the presentation client will force a one-at-a-time view and remove the "book view" option.
 
-{% include manifest_links.html viewers="UV, Mirador, Theseus, TIFY" manifest="manifest-individuals.json" %}
+{% include manifest_links.html viewers="UV, Mirador, Theseus, TIFY, Triiiceratops" manifest="manifest-individuals.json" %}
 
 {% include jsonviewer.html src="manifest-individuals.json" config='data-line="10-12"' %}
 

--- a/recipe/0019-html-in-annotations/index.md
+++ b/recipe/0019-html-in-annotations/index.md
@@ -10,6 +10,7 @@ viewers:
   - Glycerine Viewer
   - Theseus
   - TIFY
+  - Triiiceratops
 topic:
  - basic
 code:
@@ -46,7 +47,7 @@ If you have requirements outside of these rules you may be able to configure a c
 
 This example Manifest contains an embedded Annotation containing the HTML text "Göttinger Marktplatz mit Gänseliesel Brunnen" with a link to the Wikipedia Article "Gänseliesel-Brunnen (Göttingen)" behind the words "Gänseliesel Brunnen" and an image of the Wikipedia logo. The Annotation has the motivation `commenting` targeting the whole Canvas. The Annotation is the single content of an Annotation Page contained in the `annotations` property of the Canvas.
 
-{% include manifest_links.html viewers="Mirador,Annona, Glycerine Viewer, Theseus, TIFY" manifest="manifest.json" %}
+{% include manifest_links.html viewers="Mirador,Annona, Glycerine Viewer, Theseus, TIFY, Triiiceratops" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" config='data-line="53-58"' %}
 

--- a/recipe/0021-tagging/index.md
+++ b/recipe/0021-tagging/index.md
@@ -11,6 +11,7 @@ viewers:
  - Theseus
  - liiive
  - TIFY
+ - Triiiceratops
 topic: annotation
 code:
  - iiif-prezi3
@@ -36,7 +37,7 @@ In this Manifest, we use a photograph of Göttingen from the 2019 IIIF annual co
 
 Because the statue is not the sole or dominant element of the photo, we've targeted the tag to a portion of the photo using fragment selector syntax.
 
-{% include manifest_links.html viewers="Mirador,Annona,Glycerine Viewer, Theseus, liiive, TIFY" manifest="manifest.json" %}
+{% include manifest_links.html viewers="Mirador,Annona,Glycerine Viewer, Theseus, liiive, TIFY, Triiiceratops" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" config='data-line="44-63"' %}
 

--- a/recipe/0024-book-4-toc/index.md
+++ b/recipe/0024-book-4-toc/index.md
@@ -10,6 +10,7 @@ viewers:
  - Theseus
  - Glycerine Viewer
  - TIFY
+ - Triiiceratops
 topic: structure
 property: structures
 ---
@@ -39,7 +40,7 @@ In this example, an Ethiopic manuscript contains multiple works, one of which co
     * Monday
     * Tuesday
 
-{% include manifest_links.html viewers="UV, Mirador, Glycerine Viewer, Theseus, TIFY" manifest="manifest.json" %}
+{% include manifest_links.html viewers="UV, Mirador, Glycerine Viewer, Theseus, TIFY, Triiiceratops" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" config='data-line="246-326, 247-254, 275-282"' %}
 

--- a/recipe/0027-alternative-page-order/index.md
+++ b/recipe/0027-alternative-page-order/index.md
@@ -5,6 +5,7 @@ layout: recipe
 tags: [book, presentation]
 summary: "Using Ranges to offer alternative orderings of book pages."
 viewers:
+ - Triiiceratops
 topic:
  - structure
 ---
@@ -29,7 +30,7 @@ Two Ranges are provided within the `structures` to represent this case study. Fr
 
 Images provided by permission of Biblioteca Civica Bertoliana.
 
-{% include manifest_links.html viewers="" manifest="manifest.json" %}
+{% include manifest_links.html viewers="Triiiceratops" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" config='data-line="200-261"' %}
 

--- a/recipe/0029-metadata-anywhere/index.md
+++ b/recipe/0029-metadata-anywhere/index.md
@@ -14,6 +14,7 @@ viewers:
  - Theseus
  - Curation
  - TIFY
+ - Triiiceratops
 topic: property
 property: metadata
 ---
@@ -40,7 +41,7 @@ Note: Clover supports Metadata at the Manifest level but not down at the Canvas.
 
 Credit: *John Dee performing an experiment before Queen Elizabeth I*. Oil painting by Henry Gillard Glindoni. Credit: Wellcome Collection. Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)
 
-{% include manifest_links.html viewers="UV, Mirador, Annona, Clover, Glycerine Viewer, Theseus, Curation, TIFY" manifest="manifest.json" %}
+{% include manifest_links.html viewers="UV, Mirador, Annona, Clover, Glycerine Viewer, Theseus, Curation, TIFY, Triiiceratops" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" config='data-line="10-59, 83-96, 136-149"' %}
 

--- a/recipe/0030-multi-volume/index.md
+++ b/recipe/0030-multi-volume/index.md
@@ -11,6 +11,7 @@ viewers:
  - Glycerine Viewer
  - Theseus
  - TIFY
+ - Triiiceratops
 topic: structure
 ---
 
@@ -38,19 +39,19 @@ Following the Collection resource are the two Manifests for vol. 1 and vol. 2 th
 
 **Example Collection for the multi-volume work *青楼絵本年中行事 [Seirō ehon nenjū gyōji]*:**
 
-{% include manifest_links.html viewers="UV, Mirador, Annona, Glycerine Viewer, Theseus, TIFY" manifest="collection.json" %}
+{% include manifest_links.html viewers="UV, Mirador, Annona, Glycerine Viewer, Theseus, TIFY, Triiiceratops" manifest="collection.json" %}
 
 {% include jsonviewer.html src="collection.json" config='data-line="4, 10-12"' %}
 
 **Example Manifest for vol. 1 of *青楼絵本年中行事 [Seirō ehon nenjū gyōji]*:**
 
-{% include manifest_links.html viewers="UV, Mirador, Annona, Glycerine Viewer, Theseus, TIFY" manifest="manifest_v1.json" %}
+{% include manifest_links.html viewers="UV, Mirador, Annona, Glycerine Viewer, Theseus, TIFY, Triiiceratops" manifest="manifest_v1.json" %}
 
 {% include jsonviewer.html src="manifest_v1.json" %}
 
 **Example Manifest for vol. 2 of *青楼絵本年中行事 [Seirō ehon nenjū gyōji]*:**
 
-{% include manifest_links.html viewers="UV, Mirador, Annona, Glycerine Viewer, Theseus, TIFY" manifest="manifest_v2.json" %}
+{% include manifest_links.html viewers="UV, Mirador, Annona, Glycerine Viewer, Theseus, TIFY, Triiiceratops" manifest="manifest_v2.json" %}
 
 {% include jsonviewer.html src="manifest_v2.json" %}
 

--- a/recipe/0031-bound-multivolume/index.md
+++ b/recipe/0031-bound-multivolume/index.md
@@ -10,6 +10,7 @@ viewers:
  - Theseus
  - Glycerine Viewer
  - TIFY
+ - Triiiceratops
 topic:
  - structure
 ---
@@ -69,7 +70,7 @@ This will produce an index of the constituent volumes like so:
 * Erste Ausgabe... (Vol. 1)
 * Zweyte Ausgabe... (Vol. 2)
 
-{% include manifest_links.html viewers="UV, Mirador, Glycerine Viewer, Theseus, TIFY" manifest="manifest.json" %}
+{% include manifest_links.html viewers="UV, Mirador, Glycerine Viewer, Theseus, TIFY, Triiiceratops" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" config='data-line="246-315"'%}
 

--- a/recipe/0032-collection/index.md
+++ b/recipe/0032-collection/index.md
@@ -12,6 +12,7 @@ viewers:
  - Glycerine Viewer
  - Theseus
  - TIFY
+ - Triiiceratops
 topic:
  - basic
 ---
@@ -53,19 +54,19 @@ Note: Each supporting viewer has a distinct method for toggling between Collecti
 
 **Example Collection**
 
-{% include manifest_links.html viewers="UV, Mirador, Annona, Clover, Glycerine Viewer, Theseus, TIFY" manifest="collection.json" %}
+{% include manifest_links.html viewers="UV, Mirador, Annona, Clover, Glycerine Viewer, Theseus, TIFY, Triiiceratops" manifest="collection.json" %}
 
 {% include jsonviewer.html src="collection.json" %}
 
 **Example Manifest for _The Gulf Stream_**
 
-{% include manifest_links.html viewers="UV, Mirador, Annona, Clover, Glycerine Viewer, Theseus, TIFY" manifest="manifest-01.json" %}
+{% include manifest_links.html viewers="UV, Mirador, Annona, Clover, Glycerine Viewer, Theseus, TIFY, Triiiceratops" manifest="manifest-01.json" %}
 
 {% include jsonviewer.html src="manifest-01.json" %}
 
 **Example Manifest for _Northeaster_**
 
-{% include manifest_links.html viewers="UV, Mirador, Annona, Clover, Glycerine Viewer, Theseus, TIFY" manifest="manifest-02.json" %}
+{% include manifest_links.html viewers="UV, Mirador, Annona, Clover, Glycerine Viewer, Theseus, TIFY, Triiiceratops" manifest="manifest-02.json" %}
 
 {% include jsonviewer.html src="manifest-02.json" %}
 

--- a/recipe/0033-choice/index.md
+++ b/recipe/0033-choice/index.md
@@ -10,6 +10,7 @@ viewers:
  - Annona
  - Theseus
  - TIFY
+ - Triiiceratops
 topic: structure
 property:
 ---
@@ -71,7 +72,7 @@ In this example, we have a single Canvas with the `body.type` "Choice" containin
 
 Credit: *John Dee performing an experiment before Queen Elizabeth I*. Oil painting by Henry Gillard Glindoni. Credit: Wellcome Collection. Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)
 
-{% include manifest_links.html viewers="Mirador, Annona, Theseus, TIFY" manifest="manifest.json" %}
+{% include manifest_links.html viewers="Mirador, Annona, Theseus, TIFY, Triiiceratops" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" config='data-line="25-67"' %}
 

--- a/recipe/0035-foldouts/index.md
+++ b/recipe/0035-foldouts/index.md
@@ -6,6 +6,7 @@ tags: [images, behavior, non-paged]
 summary: "Demonstrates how to model a foldout diagram or map."
 viewers:
  - Theseus
+ - Triiiceratops
 topic: structure
 property: behavior
 ---
@@ -52,7 +53,7 @@ The "non-paged" behavior on Canvases is not yet supported by viewers making this
 
 ![thumbnail layout example with non-paged](layout_example1.jpg)
 
-{% include manifest_links.html viewers="Theseus" manifest="manifest.json" %}
+{% include manifest_links.html viewers="Theseus, Triiiceratops" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" config='data-line="10-12, 134-136"' %}
 

--- a/recipe/0036-composition-from-multiple-images/index.md
+++ b/recipe/0036-composition-from-multiple-images/index.md
@@ -10,6 +10,7 @@ viewers:
 - Annona
 - Theseus
 - TIFY
+- Triiiceratops
 topic: structure
 property:
 ---
@@ -62,7 +63,7 @@ A manifest with a single canvas that has two images painted on it. One is of the
 
 *Note: Currently, Mirador 3 only partially supports the layering of multiple images on a single Canvas and it is particularly noteworthy in this use case. While previous iterations of Mirador processed the images upwards from the first painting annotation, Mirador 3 does this in reverse. This means that the second image (the missing illustration detail) is hidden behind the image of the full folio and the user cannot view the reconstructed scene.*
 
-{% include manifest_links.html viewers="Mirador, Annona, Theseus, TIFY" manifest="manifest.json" %}
+{% include manifest_links.html viewers="Mirador, Annona, Theseus, TIFY, Triiiceratops" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" config='data-line="22-45, 46-70"' %}
 

--- a/recipe/0046-rendering/index.md
+++ b/recipe/0046-rendering/index.md
@@ -11,6 +11,7 @@ viewers:
  - Glycerine Viewer
  - Theseus
  - TIFY
+ - Triiiceratops
 topic: property
 property: rendering
 ---
@@ -46,7 +47,7 @@ In this example, a PDF is made available for the program as a whole, and as such
 
 To see the property in action in Mirador, toggle the sidebar by activating the three-line ("hamburger") menu in the upper left-hand corner of the content window. You should then, in the "Related" area, see the link under the "Alternate formats" heading.
 
-{% include manifest_links.html viewers="Mirador,Annona,Clover,Glycerine Viewer, Theseus, TIFY" manifest="manifest.json" %}
+{% include manifest_links.html viewers="Mirador,Annona,Clover,Glycerine Viewer, Theseus, TIFY, Triiiceratops" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" config='data-line="16-27"' %}
 

--- a/recipe/0047-homepage/index.md
+++ b/recipe/0047-homepage/index.md
@@ -11,6 +11,7 @@ viewers:
   - Glycerine Viewer
   - Theseus
   - TIFY
+  - Triiiceratops
 topic: property
 property: homepage
 ---
@@ -39,7 +40,7 @@ In this example we have a Manifest representing an object housed at the Getty Mu
 
 _Laocöon_. Credit: Getty.
 
-{% include manifest_links.html viewers="Mirador, Clover, Annona, Glycerine Viewer, Theseus, TIFY" manifest="manifest.json" %}
+{% include manifest_links.html viewers="Mirador, Clover, Annona, Glycerine Viewer, Theseus, TIFY, Triiiceratops" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" config='data-line="10-24"' %}
 

--- a/recipe/0053-seeAlso/index.md
+++ b/recipe/0053-seeAlso/index.md
@@ -11,6 +11,7 @@ viewers:
  - Glycerine Viewer
  - Theseus
  - TIFY
+ - Triiiceratops
 topic: property
 property: seeAlso
 ---
@@ -48,7 +49,7 @@ A consistent URI to use for the `profile` value for MODS can be found in [the II
 
 To see the property in action in Mirador, toggle the sidebar by activating the three-line ("hamburger") menu in the upper left-hand corner of the content window. You should then, in the "Related" area, see the link in the "Related" section under the "See also" subheading.
 
-{% include manifest_links.html viewers="Mirador, Annona, Clover, Glycerine Viewer, Theseus, TIFY" manifest="manifest.json" %}
+{% include manifest_links.html viewers="Mirador, Annona, Clover, Glycerine Viewer, Theseus, TIFY, Triiiceratops" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" config='data-line="16-28"' %}
 

--- a/recipe/0117-add-image-thumbnail/index.md
+++ b/recipe/0117-add-image-thumbnail/index.md
@@ -9,6 +9,7 @@ viewers:
  - Clover
  - Glycerine Viewer
  - Theseus
+ - Triiiceratops
 topic: property
 property: thumbnail
 ---
@@ -33,7 +34,7 @@ None known.
 
 This example uses an image of the cover of the same kabuki performance program as in the recipe for [Viewing direction and its effect on navigation][0010]. This image, though, has a color bar and the Manifest contains an explicit `thumbnail` property for the Manifest. In this particular use case, to avoid having a Manifest thumbnail image with a color calibration bar, you can choose to declare a thumbnail from a completely different image. Keep in mind that this thumbnail is just for the Manifest; no thumbnail has been explicitly set for the sole resource, so the supporting viewers should use the resource's IIIF Image service to create one.
 
-{% include manifest_links.html viewers="Mirador, Clover, Glycerine Viewer, Theseus" manifest="manifest.json" %}
+{% include manifest_links.html viewers="Mirador, Clover, Glycerine Viewer, Theseus, Triiiceratops" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" %}
 

--- a/recipe/0118-multivalue/index.md
+++ b/recipe/0118-multivalue/index.md
@@ -12,6 +12,7 @@ viewers:
  - Theseus
  - Curation
  - TIFY
+ - Triiiceratops
 topic: property
 property: label, summary, metadata, requiredStatement
 ---
@@ -34,7 +35,7 @@ None
 
 In this example, the work has multiple titles in both English and French. The Manifest `label` provides a single title in French within a single-value array (lines 6–8). The alternative titles are provided in the `metadata` property in both English and French, each with variants contained within two separate arrays -- one array for English (lines 18–21) and one for French (lines 22–25). In the `summary` property (lines 30–32) the value is included as a single-string array.
 
-{% include manifest_links.html viewers="UV, Mirador, Annona, Glycerine Viewer, Theseus, Curation, TIFY" manifest="manifest.json" %}
+{% include manifest_links.html viewers="UV, Mirador, Annona, Glycerine Viewer, Theseus, Curation, TIFY, Triiiceratops" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" config='data-line="6-8, 18-21, 22-25, 30-32"'%}
 

--- a/recipe/0135-annotating-point-in-canvas/index.md
+++ b/recipe/0135-annotating-point-in-canvas/index.md
@@ -7,6 +7,7 @@ summary: "This recipe explains how to annotate a specific point of an image."
 viewers:
  - Glycerine Viewer
  - Theseus
+ - Triiiceratops
 topic:
  - annotation
 ---
@@ -26,7 +27,7 @@ Viewers might consider implementing scale-independent point markers so that they
 
 This example uses a leaflet with a map and a guide supplied by the Library of Congress Geography and Map Division, it shows how we can annotate some locations expressed in the map.
 
-{% include manifest_links.html viewers="Glycerine Viewer, Theseus" manifest="manifest.json" %}
+{% include manifest_links.html viewers="Glycerine Viewer, Theseus, Triiiceratops" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" config='data-line="69-76"' %}
 

--- a/recipe/0202-start-canvas/index.md
+++ b/recipe/0202-start-canvas/index.md
@@ -10,6 +10,7 @@ viewers:
  - Glycerine Viewer
  - Theseus
  - TIFY
+ - Triiiceratops
 topic:
  - image
  - property
@@ -32,7 +33,7 @@ For an example of the `start` property using a Specific Resource with a Selector
 
 This example shows a Manifest with multiple Canvases for a book object. The `start` property specifies loading the Manifest at the second Canvas. Note that all Canvases are still displayed in the viewer and the user is able to navigate back to the first Canvas using the viewer navigation controls.
 
-{% include manifest_links.html viewers="Mirador,Annona,Glycerine Viewer, Theseus, TIFY" manifest="manifest.json" %}
+{% include manifest_links.html viewers="Mirador,Annona,Glycerine Viewer, Theseus, TIFY, Triiiceratops" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" config='data-line="10-13"'%}
 

--- a/recipe/0230-navdate/index.md
+++ b/recipe/0230-navdate/index.md
@@ -8,6 +8,7 @@ viewers:
  - UV
  - Mirador
  - Theseus
+ - Triiiceratops
 topic: property
 property: navDate
 code:
@@ -39,19 +40,19 @@ This recipe presents an imaginary Collection containing 2 instances from the run
 
 ### Collection
 
-{% include manifest_links.html viewers="UV, Mirador, Theseus" manifest="navdate-collection.json" %}
+{% include manifest_links.html viewers="UV, Mirador, Theseus, Triiiceratops" manifest="navdate-collection.json" %}
 
 {% include jsonviewer.html src="navdate-collection.json" config='data-line="35,45"' %}
 
 ### 1986 Map
 
-{% include manifest_links.html viewers="UV, Mirador, Theseus" manifest="navdate_map_2-manifest.json" %}
+{% include manifest_links.html viewers="UV, Mirador, Theseus, Triiiceratops" manifest="navdate_map_2-manifest.json" %}
 
 {% include jsonviewer.html src="navdate_map_2-manifest.json" config='data-line="10"' %}
 
 ### 1987 Map
 
-{% include manifest_links.html viewers="UV, Mirador, Theseus" manifest="navdate_map_1-manifest.json" %}
+{% include manifest_links.html viewers="UV, Mirador, Theseus, Triiiceratops" manifest="navdate_map_1-manifest.json" %}
 
 {% include jsonviewer.html src="navdate_map_1-manifest.json" config='data-line="10"' %}
 

--- a/recipe/0234-provider/index.md
+++ b/recipe/0234-provider/index.md
@@ -11,6 +11,7 @@ viewers:
  - Theseus
  - id: TIFY
    support: partial
+ - Triiiceratops
 topic: property
 property: provider
 ---
@@ -38,9 +39,9 @@ None known.
 
 In this example, we reuse the front page of a kabuki playbill that was contributed to the IIIF Cookbook by UCLA Library Digital Collections. The `id` for them as an Agent is the US Library of Congress authority ID for the UCLA Library, the `homepage` is their actual homepage, the `logo` is also for the library as a whole, and the `seeAlso` is the US Library of Congress MADS/XML. In your use of this property, you might want to and be able to unify the information in the property differently.
 
-Only Mirador implements `provider`, and only partially. The property must be on the Manifest level, Mirador will only display the text from a `label` and the image from a  `logo` under `provider`, and the information will only be found in the list of manifests.
+Note: Mirador only partially implements `provider`. The property must be on the Manifest level, Mirador will only display the text from a `label` and the image from a  `logo` under `provider`, and the information will only be found in the list of manifests.
 
-{% include manifest_links.html viewers="Mirador, Glycerine Viewer, Theseus, TIFY" manifest="manifest.json" %}
+{% include manifest_links.html viewers="Mirador, Glycerine Viewer, Theseus, TIFY, Triiiceratops" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" config='data-line="15-82"' %}
 

--- a/recipe/0261-non-rectangular-commenting/index.md
+++ b/recipe/0261-non-rectangular-commenting/index.md
@@ -10,6 +10,7 @@ viewers:
  - Glycerine Viewer
  - Theseus
  - liiive
+ - Triiiceratops
 topic: annotation
 ---
 
@@ -56,7 +57,7 @@ This approach should not be used to describe non-rotated rectangular regions.
 
 In this Manifest, we are highlighting a fountain with a statue on top of it and imagining that we want to be fairly precise in our highlight. The client should not show the bounding box on the image.
 
-{% include manifest_links.html viewers="Mirador,Annona,Glycerine Viewer, Theseus, liiive" manifest="manifest.json" %}
+{% include manifest_links.html viewers="Mirador,Annona,Glycerine Viewer, Theseus, liiive, Triiiceratops" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" config='data-line="44-70"' %}
 

--- a/recipe/0266-full-canvas-annotation/index.md
+++ b/recipe/0266-full-canvas-annotation/index.md
@@ -10,6 +10,7 @@ viewers:
  - Glycerine Viewer
  - Theseus
  - TIFY
+ - Triiiceratops
 topic: annotation
 ---
 
@@ -41,7 +42,7 @@ This example Manifest contains an embedded Annotation containing the text "Gött
 
 Note that viewers may not add a visual indicator of the Annotation when it targets the Canvas as a whole, or may only add it under certain circumstances, such as when targeting with a fragment.
 
-{% include manifest_links.html viewers="Mirador,Annona,Glycerine Viewer, Theseus, TIFY" manifest="manifest.json" %}
+{% include manifest_links.html viewers="Mirador,Annona,Glycerine Viewer, Theseus, TIFY, Triiiceratops" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" config='data-line="44-63"' %}
 

--- a/recipe/0269-embedded-or-referenced-annotations/index.md
+++ b/recipe/0269-embedded-or-referenced-annotations/index.md
@@ -11,6 +11,7 @@ viewers:
  - Glycerine Viewer
  - Theseus
  - TIFY
+ - Triiiceratops
 ---
 
 ## Use Case
@@ -54,7 +55,7 @@ The rendering of this referenced Annotation should be virtually indistiguishable
 
 ### Manifest file
 
-{% include manifest_links.html viewers="Mirador, Annona, Glycerine Viewer, Theseus, TIFY" manifest="manifest.json" %}
+{% include manifest_links.html viewers="Mirador, Annona, Glycerine Viewer, Theseus, TIFY, Triiiceratops" manifest="manifest.json" %}
 
 {% include jsonviewer.html src="manifest.json" config='data-line="44-49"' %}
 

--- a/recipe/0283-missing-image/index.md
+++ b/recipe/0283-missing-image/index.md
@@ -11,6 +11,7 @@ viewers:
  - Theseus
  - Curation
  - TIFY
+ - Triiiceratops
 topic:
  - image
  - basic

--- a/recipe/0299-region/index.md
+++ b/recipe/0299-region/index.md
@@ -8,6 +8,7 @@ viewers:
  - Annona
  - Glycerine Viewer
  - Theseus
+ - Triiiceratops
 topic:
  - basic
 ---
@@ -40,7 +41,7 @@ This recipe can not be applied to pulling a temporal segment from a time-based I
 
 In this example we use an ImageApiSelector on the `body` of the Manifest's sole Annotation to retrieve a single article selection from the 16 February 1925 issue of _Berliner Tageblatt_. The article discusses a meeting including Neville Chamberlain of Great Britain.
 
-{% include manifest_links.html viewers="Annona, Glycerine Viewer, Theseus" manifest="manifest.json" %}
+{% include manifest_links.html viewers="Annona, Glycerine Viewer, Theseus, Triiiceratops" manifest="manifest.json" %}
 {% include jsonviewer.html src="manifest.json" config="data-line='14-15,25-48'" %}
 
 ## Related Recipes

--- a/recipe/matrix.md
+++ b/recipe/matrix.md
@@ -17,6 +17,7 @@ viewers:
   - Curation
   - liiive
   - TIFY
+  - Triiiceratops
 topics:
   - basic
   - property
@@ -39,7 +40,7 @@ In the 2021 Working meeting there was a presentation on viewer support for IIIF 
 
 ## Which viewers are included?
 
-Currently [Mirador](https://projectmirador.org/), the [Universal Viewer](https://universalviewer.io/) (UV) V3, [Annona](https://ncsu-libraries.github.io/annona/multistoryboard/), [Clover](https://samvera-labs.github.io/clover-iiif/), [Navplace Viewer](https://map.rerum.io/), [Ramp](https://iiif-react-media-player.netlify.app/), [Aviary](https://iiif.aviaryplatform.com/), [Glycerine](https://demo.viewer.glycerine.io/), [Theseus](https://theseusviewer.org/), [Curation Viewer](https://codh.rois.ac.jp/software/iiif-curation-viewer/), [liiive](https://liiive.now/) and [TIFY](https://tify.rocks/) are listed on the cookbook. We welcome the addition of other IIIF viewers, but they must support the following features:
+Currently [Mirador](https://projectmirador.org/), the [Universal Viewer](https://universalviewer.io/) (UV) V3, [Annona](https://ncsu-libraries.github.io/annona/multistoryboard/), [Clover](https://samvera-labs.github.io/clover-iiif/), [Navplace Viewer](https://map.rerum.io/), [Ramp](https://iiif-react-media-player.netlify.app/), [Aviary](https://iiif.aviaryplatform.com/), [Glycerine](https://demo.viewer.glycerine.io/), [Theseus](https://theseusviewer.org/), [Curation Viewer](https://codh.rois.ac.jp/software/iiif-curation-viewer/), [liiive](https://liiive.now/), [TIFY](https://tify.rocks/) and [Triiiceratops](https://d-flood.github.io/triiiceratops/) are listed on the cookbook. We welcome the addition of other IIIF viewers, but they must support the following features:
 
 - Support for the [IIIF version 3.0 Presentation API](https://iiif.io/api/presentation/3.0/)
 - A public, linkable instance, ideally using the `iiif-content` parameter from the [IIIF Content State API](https://iiif.io/api/content-state/)

--- a/scripts/evaluate_viewer.py
+++ b/scripts/evaluate_viewer.py
@@ -1,0 +1,44 @@
+import sys
+import frontmatter
+import subprocess
+import os
+from viewerTests import findFilesToValidate, loadYAML
+
+# - [ ] [🔗 0004 canvas-size](https://preview.iiif.io/cookbook/feature/curation-viewer/recipe/0004-canvas-size/)
+if __name__ == "__main__":
+    # pass in a argument for the viewer to review
+    if len(sys.argv) < 2:
+        print("Usage: python evaluate_viewer.py <viewer>")
+        sys.exit(1)
+    
+    # project dir: get the directory above the directory of the script
+    project_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    
+    viewer = sys.argv[1]
+
+    files = findFilesToValidate(f"{project_dir}/recipe", ".md")
+    ignore = [f"{project_dir}/recipe/index.md", f"{project_dir}/recipe/matrix.md", f"{project_dir}/recipe/all.md", f"{project_dir}/recipe/code.md"]
+    
+    ignoreFromViewerMatrix = loadYAML(f"{project_dir}/_data/viewer_ignore.yml")
+    filename="uv.csv"
+
+    # get git branch and store it in branch
+    branch = subprocess.check_output(["git", "rev-parse", "--abbrev-ref", "HEAD"]).decode("utf-8").strip()
+
+    print(f"## Evaluating {viewer}")
+    print(f"[Viewer matrix](https://preview.iiif.io/cookbook/{branch}/recipe/matrix/)")
+    print()
+    print("Checklist:")
+    # order by recipe id which is the first part of the filename
+    files.sort(key=lambda x: x.split("/")[-2].split("-")[0])
+    for recipepath in files:
+        # get recipe name from path
+        if recipepath not in ignore:
+            #print (f"Processing {recipepath}")
+            recipe_name = recipepath.split("/")[-2]
+            recipe = frontmatter.load(recipepath)
+
+            recipe_id = recipe_name.split("-")[0]
+
+            if recipe.get('viewers', []) is not None and viewer in recipe.get('viewers', []):
+                print(f" - [ ] [🔗 {recipe_id} - {recipe.get('title')}](https://preview.iiif.io/cookbook/{branch}/recipe/{recipe_name}/)")


### PR DESCRIPTION
Update outdated statement about viewer support for `provider`

This PR adds Triiiceratops to list of viewers, to the matrix, and to each of the cookbook recipes for which it supports.

    Triiiceratops website: https://d-flood.github.io/triiiceratops/
    Triiiceratops source code: https://github.com/d-flood/triiiceratops


Moving branch from https://github.com/IIIF/cookbook-recipes/pull/677 locally so we can get the actions to run