### PR TITLE
[0318-navPlace-navDate] Update last navDate

### DIFF
--- a/recipe/0318-navPlace-navDate/collection.json
+++ b/recipe/0318-navPlace-navDate/collection.json
@@ -36,7 +36,7 @@
           "Castel Sant'Angelo, Rome"
         ]
       },
-      "navDate": "1776-01-01T00:00:00+00:00",
+      "navDate": "1776-01-01T00:00:00Z",
       "navPlace": {
         "id": "{{ id.path }}/feature-collection/1",
         "type": "FeatureCollection",


### PR DESCRIPTION
Looks like there was a recent-ish [commit](https://github.com/IIIF/cookbook-recipes/commit/2041685618372c5afc335d47362d500d33a72cc8) to update the `navDate`(s) in this recipe, but there was one that was missed. This PR fixes the last straggler.