### PR TITLE
Missing [0103] recipe from front page

### DIFF
--- a/_includes/links.md
+++ b/_includes/links.md
@@ -44,6 +44,7 @@
 [0068]: {{ site.cookbook_url | absolute_url }}/recipe/0068-newspaper/ "Basic Newspaper"
 
 [0074]: {{ site.cookbook_url | absolute_url}}/recipe/0074-multiple-language-captions/ "Using Caption and Subtitle Files in Multiple Languages with Video Content"
+[0103]: {{ site.cookbook_url | absolute_url}}/recipe/0103-poetry-reading-annotations/ "Scholarly Annotation of a Poetry Reading"
 
 [0117]: {{ site.cookbook_url | absolute_url }}/recipe/0117-add-image-thumbnail/ "Image Thumbnail for Manifest"
 [0118]: {{ site.cookbook_url | absolute_url }}/recipe/0118-multivalue/ "Displaying Multiple Values with Language Maps"

--- a/index.md
+++ b/index.md
@@ -67,6 +67,7 @@ _The corresponding 2.1 test fixture(s) is given like this, where appropriate: ..
 
 * [Transcription of image-based content][016]
 * [Using Transcripts with A/V Content][0017]
+* [Scholarly Annotation of a Poetry Reading][0103]
 * [Using Captions and Subtitles with Video Content][0219]
 * Transcription of content into XML, with XPaths to select a segment
 * [Providing Alternative Representations][0046]


### PR DESCRIPTION
This isn't listed on the list of recipes:

https://iiif.io/api/cookbook/recipe/0103-poetry-reading-annotations/